### PR TITLE
Case sensitive check for DBaaS lifecycle status

### DIFF
--- a/docs/examples/database/adw/variables.tf
+++ b/docs/examples/database/adw/variables.tf
@@ -34,5 +34,5 @@ variable "autonomous_data_warehouse_backup_display_name" {
 }
 
 variable "autonomous_data_warehouse_backup_state" {
-  default = "AVAILABLE"
+  default = "Available"
 }


### PR DESCRIPTION
line 37, the value for default should be "Available". as it appears that the field is case sensitive.