### PR TITLE
Change `make test` to a noop

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,9 +16,6 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
-	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=120s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 $(prefix) go test $(TEST) -v $(TESTARGS) $(run_regex) -timeout $(timeout)


### PR DESCRIPTION
Right now the provider doesn't seem to have an easy way to distinguish between tests that are acceptance tests and tests that aren't, our testing framework uses an environment variable to know whether or not to run (inside `resource.Test`), the problem is that the suites run that outside `resource.Test`, and so environment variables are checked for even if the test won't run, for now we are just going to make offline/unit testing a no-op in the release process, we can circle back on it later and see if we can come up with a way to toggle between the 2 test modes.