### PR TITLE
hotfix for example fix in lb_full

### DIFF
--- a/docs/examples/load_balancer/lb_full/lb_full.tf
+++ b/docs/examples/load_balancer/lb_full/lb_full.tf
@@ -331,7 +331,7 @@ resource "oci_load_balancer_rule_set" "test_rule_set" {
   }
 
   load_balancer_id = "${oci_load_balancer.lb1.id}"
-  name             = "example-rule-set-name"
+  name             = "example_rule_set_name"
 }
 
 output "lb_public_ip" {


### PR DESCRIPTION
## 3.12.1 (January 16, 2019)

### Fixed
- Fixed load balancer example to use valid rule set name