### PR TITLE
Release 3.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support for provider service keys in Fast Connect Provider Services
 - Singular data sources for User, Group, File Storage Snapshot, Private IP and Virtual Cloud Network (VCN).
 - Support for authentication policy introduced in v3.18.0 is now generally available.
+- Support for import in dbHomes and dbSystems
 
 ### Fixed
 - Virtual Circuit update failures by handling default values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 3.21.1 (Unreleased)
+## 3.22.0 (Unreleased)
+
+### Added
+- Support for `compartment_id` filter in `email_senders` and `email_suppressions` data sources
+
 ## 3.21.0 (April 03, 2019)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - Support for `compartment_id` filter in `email_senders` and `email_suppressions` data sources
 
+### Fixed
+- Backward compatibility for compositeId in Object Storage - Objects and PARs
+
 ## 3.21.0 (April 03, 2019)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Support for `compartment_id` filter in `email_senders` and `email_suppressions` data sources
+- Support for import in dbHomes and dbSystems
 
 ### Fixed
 - Backward compatibility for compositeId in Object Storage - Objects and PARs
@@ -15,7 +16,6 @@
 - Support for provider service keys in Fast Connect Provider Services
 - Singular data sources for User, Group, File Storage Snapshot, Private IP and Virtual Cloud Network (VCN).
 - Support for authentication policy introduced in v3.18.0 is now generally available.
-- Support for import in dbHomes and dbSystems
 
 ### Fixed
 - Virtual Circuit update failures by handling default values

--- a/examples/object_storage/object.tf
+++ b/examples/object_storage/object.tf
@@ -1,7 +1,7 @@
 // Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
 
 /* This example demonstrates object store object management. It uses Terraforms built-in `file` function to upload a file.
- * 
+ *
  * WARNING: This should only be used with small files. The file helper does stringification so large files
  * may cause terraform to slow, become unresponsive or exceed allowed memory usage.
  */

--- a/oci/crud_helpers.go
+++ b/oci/crud_helpers.go
@@ -419,6 +419,11 @@ func FilterMissingResourceError(sync ResourceVoider, err *error) {
 	}
 }
 
+// In the Exadata case the service return the hostname provided by the service with a suffix
+func dbSystemHostnameDiffSuppress(key string, old string, new string, d *schema.ResourceData) bool {
+	return EqualIgnoreCaseSuppressDiff(key, old, new, d) || strings.HasPrefix(strings.ToLower(old), strings.ToLower(new))
+}
+
 func EqualIgnoreCaseSuppressDiff(key string, old string, new string, d *schema.ResourceData) bool {
 	return strings.EqualFold(old, new)
 }

--- a/oci/database_db_home_resource.go
+++ b/oci/database_db_home_resource.go
@@ -16,6 +16,9 @@ import (
 
 func DatabaseDbHomeResource() *schema.Resource {
 	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: &TwelveHours,
 			Delete: &TwoHours,
@@ -463,6 +466,9 @@ func (s *DatabaseDbHomeResourceCrud) SetData() error {
 		s.D.Set("database", []interface{}{s.DatabaseToMap(s.Database)})
 	}
 
+	if source, ok := s.D.GetOkExists("source"); !ok || source.(string) == "" {
+		s.D.Set("source", "NONE")
+	}
 	return nil
 }
 

--- a/oci/database_db_home_test.go
+++ b/oci/database_db_home_test.go
@@ -241,6 +241,23 @@ func TestDatabaseDbHomeResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(singularDatasourceName, "state"),
 				),
 			},
+			// remove singular datasource from previous step so that it doesn't conflict with import tests
+			{
+				Config: config +
+					compartmentIdVariableStr + DbHomeResourceDependencies +
+					generateResourceFromRepresentationMap("oci_database_db_home", "test_db_home_source_none", Optional, Update, dbHomeRepresentationSourceNone) +
+					generateResourceFromRepresentationMap("oci_database_db_home", "test_db_home_source_db_backup", Optional, Update, dbHomeRepresentationSourceDbBackup),
+			},
+			// verify resource import
+			{
+				Config:            config,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"database.0.admin_password",
+				},
+				ResourceName: resourceName + "_source_none",
+			},
 		},
 	})
 }

--- a/oci/database_db_system_resource_test.go
+++ b/oci/database_db_system_resource_test.go
@@ -251,7 +251,6 @@ func (s *ResourceDatabaseDBSystemTestSuite) TestAccResourceDatabaseDBSystemFromB
 					resource.TestCheckResourceAttr(s.ResourceName, "license_model", "LICENSE_INCLUDED"),
 					resource.TestCheckResourceAttr(s.ResourceName, "node_count", "1"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.db_version", "12.1.0.2"),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.display_name", ""),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.admin_password", "BEstrO0ng_#11"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.db_name", "dbback"),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", string(database.DatabaseLifecycleStateAvailable)),
@@ -319,13 +318,8 @@ func (s *ResourceDatabaseDBSystemTestSuite) TestAccResourceDatabaseDBSystem_basi
 					resource.TestCheckResourceAttr(s.ResourceName, "node_count", "1"),
 					//resource.TestCheckResourceAttr(s.ResourceName, "fault_domains.#", "1"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.db_version", "12.1.0.2"),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.display_name", ""),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.admin_password", "BEstrO0ng_#11"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.db_name", "aTFdb"),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.character_set", ""),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.ncharacter_set", ""),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.db_workload", ""),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.pdb_name", ""),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", string(database.DatabaseLifecycleStateAvailable)),
 				),
 			},
@@ -619,8 +613,8 @@ func (s *ResourceDatabaseDBSystemTestSuite) TestAccResourceDatabaseDBSystem_allV
 							"admin_password" = "BEstrO0ng_#11"
 							"db_name" = "aTFdb"
 							character_set = "AL32UTF8"
-							defined_tags = "${map("example-tag-namespace-all.example-tag", "originalValue")}"
-							freeform_tags = {"Department" = "Finance"}
+							//defined_tags = "${map("example-tag-namespace-all.example-tag", "originalValue")}" // service does not set tags of db tags in create
+							//freeform_tags = {"Department" = "Finance"} // service does not set tags of db tags in create
 							ncharacter_set = "AL16UTF16"
 							db_workload = "OLTP"
 							pdb_name = "pdbName"
@@ -700,8 +694,6 @@ func (s *ResourceDatabaseDBSystemTestSuite) TestAccResourceDatabaseDBSystem_allV
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.admin_password", "BEstrO0ng_#11"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.db_name", "aTFdb"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.character_set", "AL32UTF8"),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.defined_tags.example-tag-namespace-all.example-tag", "originalValue"),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.freeform_tags.Department", "Finance"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.ncharacter_set", "AL16UTF16"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.db_workload", "OLTP"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.pdb_name", "pdbName"),
@@ -1090,13 +1082,8 @@ func (s *ResourceDatabaseDBSystemTestSuite) TestAccResourceDatabaseDBSystem_Exad
 					resource.TestCheckResourceAttr(s.ResourceName, "license_model", "LICENSE_INCLUDED"),
 					resource.TestCheckResourceAttr(s.ResourceName, "node_count", "1"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.db_version", "12.1.0.2"),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.display_name", ""),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.admin_password", "BEstrO0ng_#11"),
 					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.db_name", "aTFdb"),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.character_set", ""),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.ncharacter_set", ""),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.db_workload", ""),
-					resource.TestCheckResourceAttr(s.ResourceName, "db_home.0.database.0.pdb_name", ""),
 					resource.TestCheckResourceAttr(s.ResourceName, "state", string(database.DatabaseLifecycleStateAvailable)),
 					resource.TestCheckResourceAttr(s.ResourceName, "time_zone", "US/Pacific"),
 				),

--- a/oci/email_sender_test.go
+++ b/oci/email_sender_test.go
@@ -133,6 +133,7 @@ func TestEmailSenderResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceName, "state", "ACTIVE"),
 
 					resource.TestCheckResourceAttr(datasourceName, "senders.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "senders.0.compartment_id", compartmentId),
 					resource.TestCheckResourceAttr(datasourceName, "senders.0.defined_tags.%", "1"),
 					resource.TestCheckResourceAttr(datasourceName, "senders.0.email_address", "JohnSmith@example.com"),
 					resource.TestCheckResourceAttr(datasourceName, "senders.0.freeform_tags.%", "1"),

--- a/oci/email_senders_data_source.go
+++ b/oci/email_senders_data_source.go
@@ -102,7 +102,9 @@ func (s *EmailSendersDataSourceCrud) SetData() error {
 	resources := []map[string]interface{}{}
 
 	for _, r := range s.Res.Items {
-		sender := map[string]interface{}{}
+		sender := map[string]interface{}{
+			"compartment_id": *r.CompartmentId,
+		}
 
 		if r.DefinedTags != nil {
 			sender["defined_tags"] = definedTagsToMap(r.DefinedTags)

--- a/oci/email_suppression_test.go
+++ b/oci/email_suppression_test.go
@@ -83,6 +83,7 @@ func TestEmailSuppressionResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceName, "time_created_less_than", "2038-01-01T00:00:00.000Z"),
 
 					resource.TestCheckResourceAttr(datasourceName, "suppressions.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "suppressions.0.compartment_id", tenancyId),
 					// email address is converted to lower case by the service
 					resource.TestCheckResourceAttr(datasourceName, "suppressions.0.email_address", "johnsmith@example.com"),
 					resource.TestCheckResourceAttrSet(datasourceName, "suppressions.0.time_created"),

--- a/oci/email_suppressions_data_source.go
+++ b/oci/email_suppressions_data_source.go
@@ -120,7 +120,9 @@ func (s *EmailSuppressionsDataSourceCrud) SetData() error {
 	resources := []map[string]interface{}{}
 
 	for _, r := range s.Res.Items {
-		suppression := map[string]interface{}{}
+		suppression := map[string]interface{}{
+			"compartment_id": *r.CompartmentId,
+		}
 
 		if r.EmailAddress != nil {
 			suppression["email_address"] = *r.EmailAddress

--- a/oci/version.go
+++ b/oci/version.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-const Version = "3.21.0"
+const Version = "3.22.0"
 
 func PrintVersion() {
 	log.Printf("[INFO] terraform-provider-oci %s\n", Version)

--- a/vendor/github.com/oracle/oci-go-sdk/CHANGELOG.md
+++ b/vendor/github.com/oracle/oci-go-sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## 5.3.0 - 2019-04-09
+### Added
+- Support for etag and if-match headers (for optimistic concurrency control) in the Email service
+
 ## 5.2.0 - 2019-04-02
 ### Added
 - Support for provider service key names on virtual circuits in the FastConnect service

--- a/vendor/github.com/oracle/oci-go-sdk/common/version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/version.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	major = "5"
-	minor = "2"
+	minor = "3"
 	patch = "0"
 	tag   = ""
 )

--- a/vendor/github.com/oracle/oci-go-sdk/email/create_sender_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/email/create_sender_request_response.go
@@ -49,6 +49,9 @@ type CreateSenderResponse struct {
 	// to contact Oracle about a particular request, please provide the
 	// request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
 }
 
 func (response CreateSenderResponse) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/email/delete_sender_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/email/delete_sender_request_response.go
@@ -14,6 +14,11 @@ type DeleteSenderRequest struct {
 	// The unique OCID of the sender.
 	SenderId *string `mandatory:"true" contributesTo:"path" name:"senderId"`
 
+	// Used for optimistic concurrency control. In the update or delete call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous get, create, or update response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
 	// The request ID for tracing from the system
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/email/get_sender_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/email/get_sender_request_response.go
@@ -49,6 +49,9 @@ type GetSenderResponse struct {
 	// to contact Oracle about a particular request, please provide the
 	// request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
 }
 
 func (response GetSenderResponse) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/email/sender_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/email/sender_summary.go
@@ -16,6 +16,9 @@ import (
 // SenderSummary The email addresses and `senderId` representing an approved sender.
 type SenderSummary struct {
 
+	// The OCID for the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
 	// The email address of the sender.
 	EmailAddress *string `mandatory:"false" json:"emailAddress"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/email/suppression_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/email/suppression_summary.go
@@ -16,6 +16,9 @@ import (
 // SuppressionSummary The full information representing a suppression.
 type SuppressionSummary struct {
 
+	// The OCID for the compartment.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
 	// The email address of the suppression.
 	EmailAddress *string `mandatory:"false" json:"emailAddress"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/email/update_sender_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/email/update_sender_request_response.go
@@ -17,6 +17,11 @@ type UpdateSenderRequest struct {
 	// update details for sender.
 	UpdateSenderDetails `contributesTo:"body"`
 
+	// Used for optimistic concurrency control. In the update or delete call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous get, create, or update response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
 	// The request ID for tracing from the system
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
 
@@ -52,6 +57,9 @@ type UpdateSenderResponse struct {
 	// to contact Oracle about a particular request, please provide the
 	// request ID.
 	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
 }
 
 func (response UpdateSenderResponse) String() string {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -684,13 +684,13 @@
 			"revisionTime": "2018-03-08T00:51:04Z"
 		},
 		{
-			"checksumSHA1": "QiCWdFSQxEZzNnI0y+URtwBIDuQ=",
+			"checksumSHA1": "WLkPJds9npHynMlXYeNC+wW4pJk=",
 			"path": "github.com/oracle/oci-go-sdk",
-			"revision": "0c044aff7437fdb65d6a3b82a2c0b2b14fd059b0",
-			"revisionTime": "2019-04-04T21:12:13Z",
+			"revision": "8a0a9588f6153e492adf2f9fe7489e2eea1876e5",
+			"revisionTime": "2019-04-09T17:18:44Z",
 			"tree": true,
-			"version": "=v5.2.0",
-			"versionExact": "v5.2.0"
+			"version": "=v5.3.0",
+			"versionExact": "v5.3.0"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -684,10 +684,10 @@
 			"revisionTime": "2018-03-08T00:51:04Z"
 		},
 		{
-			"checksumSHA1": "EO5jrlsE+kLxJxxO8u49HItID9A=",
+			"checksumSHA1": "QiCWdFSQxEZzNnI0y+URtwBIDuQ=",
 			"path": "github.com/oracle/oci-go-sdk",
-			"revision": "a7988bff55b6a839874481326f12146da1f454de",
-			"revisionTime": "2019-04-02T18:23:01Z",
+			"revision": "0c044aff7437fdb65d6a3b82a2c0b2b14fd059b0",
+			"revisionTime": "2019-04-04T21:12:13Z",
 			"tree": true,
 			"version": "=v5.2.0",
 			"versionExact": "v5.2.0"

--- a/website/docs/r/database_db_home.html.markdown
+++ b/website/docs/r/database_db_home.html.markdown
@@ -113,5 +113,19 @@ The following attributes are exported:
 
 ## Import
 
-Import for `oci_database_db_home` is not supported at this time
+DbHomes can be imported using the `id`, e.g.
+
+```
+$ terraform import oci_database_db_home.test_db_home "id"
+```
+
+Import is only supported for source=NONE
+
+database.0.admin_password is not returned by the service for security reasons. To avoid a force new of the db_home on the next apply you can manually modify the statefile to add the field or you can add the following to the resource:
+
+```
+    lifecycle {
+        ignore_changes = ["database.0.admin_password"]
+    }
+```
 

--- a/website/docs/r/database_db_system.html.markdown
+++ b/website/docs/r/database_db_system.html.markdown
@@ -250,4 +250,19 @@ The following attributes are exported:
 
 ## Import
 
-Import for `oci_database_db_system` is not supported at this time
+DBSystems can be imported using the `id`, e.g.
+
+```
+$ terraform import oci_database_db_system.test_db_system "id"
+```
+
+Import is only supported for source=NONE
+
+`db_home.0.database.0.admin_password` is not returned by the service for security reasons. To avoid a force new of the db_home on the next apply you can manually modify the statefile to add the field or you can add the following to the resource:
+
+```
+    lifecycle {
+        ignore_changes = ["db_home.0.database.0.admin_password"]
+    }
+```
+You may also need to add `hostname` to the ignore_changes list if you see a diff on a subsequent apply


### PR DESCRIPTION
### Added
- Support for `compartment_id` filter in `email_senders` and `email_suppressions` data sources

### Fixed
- Backward compatibility for compositeId in Object Storage - Objects and PARs

