### PR TITLE
Use correct value for can_use_auth_tokens

### DIFF
--- a/oci/identity_user_capabilities_management_resource.go
+++ b/oci/identity_user_capabilities_management_resource.go
@@ -204,7 +204,7 @@ func (s *UserCapabilitiesManagementResourceCrud) SetData() error {
 			s.D.Set("can_use_api_keys", *s.Res.Capabilities.CanUseApiKeys)
 		}
 		if s.Res.Capabilities.CanUseAuthTokens != nil {
-			s.D.Set("can_use_auth_tokens", *s.Res.Capabilities.CanUseApiKeys)
+			s.D.Set("can_use_auth_tokens", *s.Res.Capabilities.CanUseAuthTokens)
 		}
 		if s.Res.Capabilities.CanUseConsolePassword != nil {
 			s.D.Set("can_use_console_password", *s.Res.Capabilities.CanUseConsolePassword)


### PR DESCRIPTION
The value for can_use_api_keys could override the value for can_use_auth_tokens
and this could cause issues when planning a change.

Signed-off-by: Benno van den Berg <benno.van.den.berg@oracle.com>