### PR TITLE
Add subcategories to docs for Terraform Registry

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -90,6 +90,9 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
+test-docscheck:
+	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
+
 ## Additional OCI stuff that will need to be moved eventually
 get: ;go get golang.org/x/tools/cmd/goimports; go get github.com/mitchellh/gox
 
@@ -129,4 +132,4 @@ zip:
 	tar -czvf openbsd_amd64.tar.gz openbsd_amd64; \
 	tar -czvf solaris_amd64.tar.gz solaris_amd64
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test test-docscheck

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+docs=$(ls website/docs/**/*.markdown)
+error=false
+
+for doc in $docs; do
+  dirname=$(dirname "$doc")
+  category=$(basename "$dirname")
+
+
+  case "$category" in
+    "guides")
+      # Guides have no requirements
+      continue
+      ;;
+
+    "d")
+      # Data sources have no requirements
+      continue
+      ;;
+
+		"r")
+      # Resources require a subcategory
+      grep "^subcategory: " "$doc" > /dev/null
+      if [[ "$?" == "1" ]]; then
+        echo "Doc is missing a subcategory: $doc"
+        error=true
+      fi
+      ;;
+
+    *)
+      # Docs
+      error=true
+      echo "Unknown category \"$category\". " \
+        "Docs can only exist in r/, d/, or guides/ folders."
+      ;;
+  esac
+done
+
+if $error; then
+  exit 1
+fi
+
+exit 0

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -10,26 +10,22 @@ for doc in $docs; do
 
   case "$category" in
     "guides")
-      # Guides have no requirements
-      continue
+      # Guides require a page_title
+      if ! grep "^page_title: " "$doc" > /dev/null; then
+        echo "Guide is missing a page_title: $doc"
+        error=true
+      fi
       ;;
 
-    "d")
-      # Data sources have no requirements
-      continue
-      ;;
-
-		"r")
-      # Resources require a subcategory
-      grep "^subcategory: " "$doc" > /dev/null
-      if [[ "$?" == "1" ]]; then
+    "d" | "r")
+      # Resources and data sources require a subcategory
+      if ! grep "^subcategory: " "$doc" > /dev/null; then
         echo "Doc is missing a subcategory: $doc"
         error=true
       fi
       ;;
 
     *)
-      # Docs
       error=true
       echo "Unknown category \"$category\". " \
         "Docs can only exist in r/, d/, or guides/ folders."

--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -35,6 +35,7 @@ check_make_target 3 'errcheck'
 check_make_target 5 'test-compile' 'TEST=./oci'
 check_make_target 6 'ocicheck'
 check_make_target 7 'website-test'
+check_make_target 8 'test-docscheck'
 
 
 echo "checking: make build ..."

--- a/website/docs/d/audit_configuration.html.markdown
+++ b/website/docs/d/audit_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Audit"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_audit_configuration"
 sidebar_current: "docs-oci-datasource-audit-configuration"

--- a/website/docs/d/audit_events.html.markdown
+++ b/website/docs/d/audit_events.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Audit"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_audit_events"
 sidebar_current: "docs-oci-datasource-audit-events"

--- a/website/docs/d/autoscaling_auto_scaling_configuration.html.markdown
+++ b/website/docs/d/autoscaling_auto_scaling_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_autoscaling_auto_scaling_configuration"
 sidebar_current: "docs-oci-datasource-autoscaling-auto_scaling_configuration"

--- a/website/docs/d/autoscaling_auto_scaling_configurations.html.markdown
+++ b/website/docs/d/autoscaling_auto_scaling_configurations.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_autoscaling_auto_scaling_configurations"
 sidebar_current: "docs-oci-datasource-autoscaling-auto_scaling_configurations"

--- a/website/docs/d/budget_alert_rule.html.markdown
+++ b/website/docs/d/budget_alert_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Budget"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_budget_alert_rule"
 sidebar_current: "docs-oci-datasource-budget-alert_rule"

--- a/website/docs/d/budget_alert_rules.html.markdown
+++ b/website/docs/d/budget_alert_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Budget"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_budget_alert_rules"
 sidebar_current: "docs-oci-datasource-budget-alert_rules"

--- a/website/docs/d/budget_budget.html.markdown
+++ b/website/docs/d/budget_budget.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Budget"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_budget_budget"
 sidebar_current: "docs-oci-datasource-budget-budget"

--- a/website/docs/d/budget_budgets.html.markdown
+++ b/website/docs/d/budget_budgets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Budget"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_budget_budgets"
 sidebar_current: "docs-oci-datasource-budget-budgets"

--- a/website/docs/d/containerengine_cluster_kube_config.html.markdown
+++ b/website/docs/d/containerengine_cluster_kube_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_cluster_kube_config"
 sidebar_current: "docs-oci-datasource-containerengine-cluster_kube_config"

--- a/website/docs/d/containerengine_cluster_option.html.markdown
+++ b/website/docs/d/containerengine_cluster_option.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_cluster_option"
 sidebar_current: "docs-oci-datasource-containerengine-cluster_option"

--- a/website/docs/d/containerengine_clusters.html.markdown
+++ b/website/docs/d/containerengine_clusters.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_clusters"
 sidebar_current: "docs-oci-datasource-containerengine-clusters"

--- a/website/docs/d/containerengine_node_pool.html.markdown
+++ b/website/docs/d/containerengine_node_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_node_pool"
 sidebar_current: "docs-oci-datasource-containerengine-node_pool"

--- a/website/docs/d/containerengine_node_pool_option.html.markdown
+++ b/website/docs/d/containerengine_node_pool_option.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_node_pool_option"
 sidebar_current: "docs-oci-datasource-containerengine-node_pool_option"

--- a/website/docs/d/containerengine_node_pools.html.markdown
+++ b/website/docs/d/containerengine_node_pools.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_node_pools"
 sidebar_current: "docs-oci-datasource-containerengine-node_pools"

--- a/website/docs/d/containerengine_work_request_errors.html.markdown
+++ b/website/docs/d/containerengine_work_request_errors.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_work_request_errors"
 sidebar_current: "docs-oci-datasource-containerengine-work_request_errors"

--- a/website/docs/d/containerengine_work_request_log_entries.html.markdown
+++ b/website/docs/d/containerengine_work_request_log_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_work_request_log_entries"
 sidebar_current: "docs-oci-datasource-containerengine-work_request_log_entries"

--- a/website/docs/d/containerengine_work_requests.html.markdown
+++ b/website/docs/d/containerengine_work_requests.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_work_requests"
 sidebar_current: "docs-oci-datasource-containerengine-work_requests"

--- a/website/docs/d/core_app_catalog_listing.html.markdown
+++ b/website/docs/d/core_app_catalog_listing.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_app_catalog_listing"
 sidebar_current: "docs-oci-datasource-core-app_catalog_listing"

--- a/website/docs/d/core_app_catalog_listing_resource_version.html.markdown
+++ b/website/docs/d/core_app_catalog_listing_resource_version.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_app_catalog_listing_resource_version"
 sidebar_current: "docs-oci-datasource-core-app_catalog_listing_resource_version"

--- a/website/docs/d/core_app_catalog_listing_resource_versions.html.markdown
+++ b/website/docs/d/core_app_catalog_listing_resource_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_app_catalog_listing_resource_versions"
 sidebar_current: "docs-oci-datasource-core-app_catalog_listing_resource_versions"

--- a/website/docs/d/core_app_catalog_listings.html.markdown
+++ b/website/docs/d/core_app_catalog_listings.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_app_catalog_listings"
 sidebar_current: "docs-oci-datasource-core-app_catalog_listings"

--- a/website/docs/d/core_app_catalog_subscriptions.html.markdown
+++ b/website/docs/d/core_app_catalog_subscriptions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_app_catalog_subscriptions"
 sidebar_current: "docs-oci-datasource-core-app_catalog_subscriptions"

--- a/website/docs/d/core_boot_volume.html.markdown
+++ b/website/docs/d/core_boot_volume.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_boot_volume"
 sidebar_current: "docs-oci-datasource-core-boot_volume"

--- a/website/docs/d/core_boot_volume_attachments.html.markdown
+++ b/website/docs/d/core_boot_volume_attachments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_boot_volume_attachments"
 sidebar_current: "docs-oci-datasource-core-boot_volume_attachments"

--- a/website/docs/d/core_boot_volume_backup.html.markdown
+++ b/website/docs/d/core_boot_volume_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_boot_volume_backup"
 sidebar_current: "docs-oci-datasource-core-boot_volume_backup"

--- a/website/docs/d/core_boot_volume_backups.html.markdown
+++ b/website/docs/d/core_boot_volume_backups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_boot_volume_backups"
 sidebar_current: "docs-oci-datasource-core-boot_volume_backups"

--- a/website/docs/d/core_boot_volumes.html.markdown
+++ b/website/docs/d/core_boot_volumes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_boot_volumes"
 sidebar_current: "docs-oci-datasource-core-boot_volumes"

--- a/website/docs/d/core_cluster_network.html.markdown
+++ b/website/docs/d/core_cluster_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cluster_network"
 sidebar_current: "docs-oci-datasource-core-cluster_network"

--- a/website/docs/d/core_cluster_network_instances.html.markdown
+++ b/website/docs/d/core_cluster_network_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cluster_network_instances"
 sidebar_current: "docs-oci-datasource-core-cluster_network_instances"

--- a/website/docs/d/core_cluster_networks.html.markdown
+++ b/website/docs/d/core_cluster_networks.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cluster_networks"
 sidebar_current: "docs-oci-datasource-core-cluster_networks"

--- a/website/docs/d/core_console_histories.html.markdown
+++ b/website/docs/d/core_console_histories.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_console_histories"
 sidebar_current: "docs-oci-datasource-core-console_histories"

--- a/website/docs/d/core_console_history_data.html.markdown
+++ b/website/docs/d/core_console_history_data.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_console_history_data"
 sidebar_current: "docs-oci-datasource-core-console_history_content"

--- a/website/docs/d/core_cpes.html.markdown
+++ b/website/docs/d/core_cpes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cpes"
 sidebar_current: "docs-oci-datasource-core-cpes"

--- a/website/docs/d/core_cross_connect.html.markdown
+++ b/website/docs/d/core_cross_connect.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connect"
 sidebar_current: "docs-oci-datasource-core-cross_connect"

--- a/website/docs/d/core_cross_connect_group.html.markdown
+++ b/website/docs/d/core_cross_connect_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connect_group"
 sidebar_current: "docs-oci-datasource-core-cross_connect_group"

--- a/website/docs/d/core_cross_connect_groups.html.markdown
+++ b/website/docs/d/core_cross_connect_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connect_groups"
 sidebar_current: "docs-oci-datasource-core-cross_connect_groups"

--- a/website/docs/d/core_cross_connect_locations.html.markdown
+++ b/website/docs/d/core_cross_connect_locations.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connect_locations"
 sidebar_current: "docs-oci-datasource-core-cross_connect_locations"

--- a/website/docs/d/core_cross_connect_port_speed_shapes.html.markdown
+++ b/website/docs/d/core_cross_connect_port_speed_shapes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connect_port_speed_shapes"
 sidebar_current: "docs-oci-datasource-core-cross_connect_port_speed_shapes"

--- a/website/docs/d/core_cross_connect_status.html.markdown
+++ b/website/docs/d/core_cross_connect_status.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connect_status"
 sidebar_current: "docs-oci-datasource-core-cross_connect_status"

--- a/website/docs/d/core_cross_connects.html.markdown
+++ b/website/docs/d/core_cross_connects.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connects"
 sidebar_current: "docs-oci-datasource-core-cross_connects"

--- a/website/docs/d/core_dedicated_vm_host.html.markdown
+++ b/website/docs/d/core_dedicated_vm_host.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_dedicated_vm_host"
 sidebar_current: "docs-oci-datasource-core-dedicated_vm_host"

--- a/website/docs/d/core_dedicated_vm_host_instance_shapes.html.markdown
+++ b/website/docs/d/core_dedicated_vm_host_instance_shapes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_dedicated_vm_host_instance_shapes"
 sidebar_current: "docs-oci-datasource-core-dedicated_vm_host_instance_shapes"

--- a/website/docs/d/core_dedicated_vm_host_shapes.html.markdown
+++ b/website/docs/d/core_dedicated_vm_host_shapes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_dedicated_vm_host_shapes"
 sidebar_current: "docs-oci-datasource-core-dedicated_vm_host_shapes"

--- a/website/docs/d/core_dedicated_vm_hosts.html.markdown
+++ b/website/docs/d/core_dedicated_vm_hosts.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_dedicated_vm_hosts"
 sidebar_current: "docs-oci-datasource-core-dedicated_vm_hosts"

--- a/website/docs/d/core_dedicated_vm_hosts_instances.html.markdown
+++ b/website/docs/d/core_dedicated_vm_hosts_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_dedicated_vm_hosts_instances"
 sidebar_current: "docs-oci-datasource-core-dedicated_vm_hosts_instances"

--- a/website/docs/d/core_dhcp_options.html.markdown
+++ b/website/docs/d/core_dhcp_options.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_dhcp_options"
 sidebar_current: "docs-oci-datasource-core-dhcp_options"

--- a/website/docs/d/core_drg_attachments.html.markdown
+++ b/website/docs/d/core_drg_attachments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_drg_attachments"
 sidebar_current: "docs-oci-datasource-core-drg_attachments"

--- a/website/docs/d/core_drgs.html.markdown
+++ b/website/docs/d/core_drgs.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_drgs"
 sidebar_current: "docs-oci-datasource-core-drgs"

--- a/website/docs/d/core_fast_connect_provider_service.html.markdown
+++ b/website/docs/d/core_fast_connect_provider_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_fast_connect_provider_service"
 sidebar_current: "docs-oci-datasource-core-fast_connect_provider_service"

--- a/website/docs/d/core_fast_connect_provider_service_key.html.markdown
+++ b/website/docs/d/core_fast_connect_provider_service_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_fast_connect_provider_service_key"
 sidebar_current: "docs-oci-datasource-core-fast_connect_provider_service_key"

--- a/website/docs/d/core_fast_connect_provider_services.html.markdown
+++ b/website/docs/d/core_fast_connect_provider_services.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_fast_connect_provider_services"
 sidebar_current: "docs-oci-datasource-core-fast_connect_provider_services"

--- a/website/docs/d/core_images.html.markdown
+++ b/website/docs/d/core_images.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_images"
 sidebar_current: "docs-oci-datasource-core-images"

--- a/website/docs/d/core_instance.html.markdown
+++ b/website/docs/d/core_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance"
 sidebar_current: "docs-oci-datasource-core-instance"

--- a/website/docs/d/core_instance_configuration.html.markdown
+++ b/website/docs/d/core_instance_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_configuration"
 sidebar_current: "docs-oci-datasource-core-instance_configuration"

--- a/website/docs/d/core_instance_configurations.html.markdown
+++ b/website/docs/d/core_instance_configurations.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_configurations"
 sidebar_current: "docs-oci-datasource-core-instance_configurations"

--- a/website/docs/d/core_instance_console_connections.html.markdown
+++ b/website/docs/d/core_instance_console_connections.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_console_connections"
 sidebar_current: "docs-oci-datasource-core-instance_console_connections"

--- a/website/docs/d/core_instance_credentials.html.markdown
+++ b/website/docs/d/core_instance_credentials.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_credentials"
 sidebar_current: "docs-oci-datasource-core-instance_credential"

--- a/website/docs/d/core_instance_devices.html.markdown
+++ b/website/docs/d/core_instance_devices.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_devices"
 sidebar_current: "docs-oci-datasource-core-instance_devices"

--- a/website/docs/d/core_instance_pool.html.markdown
+++ b/website/docs/d/core_instance_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_pool"
 sidebar_current: "docs-oci-datasource-core-instance_pool"

--- a/website/docs/d/core_instance_pool_instances.html.markdown
+++ b/website/docs/d/core_instance_pool_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_pool_instances"
 sidebar_current: "docs-oci-datasource-core-instance_pool_instances"

--- a/website/docs/d/core_instance_pool_load_balancer_attachment.html.markdown
+++ b/website/docs/d/core_instance_pool_load_balancer_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_pool_load_balancer_attachment"
 sidebar_current: "docs-oci-datasource-core-instance_pool_load_balancer_attachment"

--- a/website/docs/d/core_instance_pools.html.markdown
+++ b/website/docs/d/core_instance_pools.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_pools"
 sidebar_current: "docs-oci-datasource-core-instance_pools"

--- a/website/docs/d/core_instances.html.markdown
+++ b/website/docs/d/core_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instances"
 sidebar_current: "docs-oci-datasource-core-instances"

--- a/website/docs/d/core_internet_gateways.html.markdown
+++ b/website/docs/d/core_internet_gateways.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_internet_gateways"
 sidebar_current: "docs-oci-datasource-core-internet_gateways"

--- a/website/docs/d/core_ipsec_config.html.markdown
+++ b/website/docs/d/core_ipsec_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_ipsec_config"
 sidebar_current: "docs-oci-datasource-core-ip_sec_connection_device_config"

--- a/website/docs/d/core_ipsec_connection_tunnel.html.markdown
+++ b/website/docs/d/core_ipsec_connection_tunnel.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_ipsec_connection_tunnel"
 sidebar_current: "docs-oci-datasource-core-ip_sec_connection_tunnel"

--- a/website/docs/d/core_ipsec_connection_tunnels.html.markdown
+++ b/website/docs/d/core_ipsec_connection_tunnels.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_ipsec_connection_tunnels"
 sidebar_current: "docs-oci-datasource-core-ipsec_connection_tunnels"

--- a/website/docs/d/core_ipsec_connections.html.markdown
+++ b/website/docs/d/core_ipsec_connections.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_ipsec_connections"
 sidebar_current: "docs-oci-datasource-core-ipsec_connections"

--- a/website/docs/d/core_ipsec_status.html.markdown
+++ b/website/docs/d/core_ipsec_status.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_ipsec_status"
 sidebar_current: "docs-oci-datasource-core-ip_sec_connection_device_status"

--- a/website/docs/d/core_letter_of_authority.html.markdown
+++ b/website/docs/d/core_letter_of_authority.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_letter_of_authority"
 sidebar_current: "docs-oci-datasource-core-letter_of_authority"

--- a/website/docs/d/core_local_peering_gateways.html.markdown
+++ b/website/docs/d/core_local_peering_gateways.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_local_peering_gateways"
 sidebar_current: "docs-oci-datasource-core-local_peering_gateways"

--- a/website/docs/d/core_nat_gateway.html.markdown
+++ b/website/docs/d/core_nat_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_nat_gateway"
 sidebar_current: "docs-oci-datasource-core-nat_gateway"

--- a/website/docs/d/core_nat_gateways.html.markdown
+++ b/website/docs/d/core_nat_gateways.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_nat_gateways"
 sidebar_current: "docs-oci-datasource-core-nat_gateways"

--- a/website/docs/d/core_network_security_group.html.markdown
+++ b/website/docs/d/core_network_security_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_network_security_group"
 sidebar_current: "docs-oci-datasource-core-network_security_group"

--- a/website/docs/d/core_network_security_group_security_rules.html.markdown
+++ b/website/docs/d/core_network_security_group_security_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_network_security_group_security_rules"
 sidebar_current: "docs-oci-datasource-core-network_security_group_security_rules"

--- a/website/docs/d/core_network_security_group_vnics.html.markdown
+++ b/website/docs/d/core_network_security_group_vnics.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_network_security_group_vnics"
 sidebar_current: "docs-oci-datasource-core-network_security_group_vnics"

--- a/website/docs/d/core_network_security_groups.html.markdown
+++ b/website/docs/d/core_network_security_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_network_security_groups"
 sidebar_current: "docs-oci-datasource-core-network_security_groups"

--- a/website/docs/d/core_peer_region_for_remote_peerings.html.markdown
+++ b/website/docs/d/core_peer_region_for_remote_peerings.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_peer_region_for_remote_peerings"
 sidebar_current: "docs-oci-datasource-core-peer_region_for_remote_peerings"

--- a/website/docs/d/core_private_ip.html.markdown
+++ b/website/docs/d/core_private_ip.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_private_ip"
 sidebar_current: "docs-oci-datasource-core-private_ip"

--- a/website/docs/d/core_private_ips.html.markdown
+++ b/website/docs/d/core_private_ips.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_private_ips"
 sidebar_current: "docs-oci-datasource-core-private_ips"

--- a/website/docs/d/core_public_ip.html.markdown
+++ b/website/docs/d/core_public_ip.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_public_ip"
 sidebar_current: "docs-oci-datasource-core-public_ip"

--- a/website/docs/d/core_public_ips.html.markdown
+++ b/website/docs/d/core_public_ips.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_public_ips"
 sidebar_current: "docs-oci-datasource-core-public_ips"

--- a/website/docs/d/core_remote_peering_connections.html.markdown
+++ b/website/docs/d/core_remote_peering_connections.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_remote_peering_connections"
 sidebar_current: "docs-oci-datasource-core-remote_peering_connections"

--- a/website/docs/d/core_route_tables.html.markdown
+++ b/website/docs/d/core_route_tables.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_route_tables"
 sidebar_current: "docs-oci-datasource-core-route_tables"

--- a/website/docs/d/core_security_lists.html.markdown
+++ b/website/docs/d/core_security_lists.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_security_lists"
 sidebar_current: "docs-oci-datasource-core-security_lists"

--- a/website/docs/d/core_service_gateways.html.markdown
+++ b/website/docs/d/core_service_gateways.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_service_gateways"
 sidebar_current: "docs-oci-datasource-core-service_gateways"

--- a/website/docs/d/core_services.html.markdown
+++ b/website/docs/d/core_services.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_services"
 sidebar_current: "docs-oci-datasource-core-services"

--- a/website/docs/d/core_shapes.html.markdown
+++ b/website/docs/d/core_shapes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_shapes"
 sidebar_current: "docs-oci-datasource-core-shapes"

--- a/website/docs/d/core_subnet.html.markdown
+++ b/website/docs/d/core_subnet.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_subnet"
 sidebar_current: "docs-oci-datasource-core-subnet"

--- a/website/docs/d/core_subnets.html.markdown
+++ b/website/docs/d/core_subnets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_subnets"
 sidebar_current: "docs-oci-datasource-core-subnets"

--- a/website/docs/d/core_vcn.html.markdown
+++ b/website/docs/d/core_vcn.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_vcn"
 sidebar_current: "docs-oci-datasource-core-vcn"

--- a/website/docs/d/core_vcns.html.markdown
+++ b/website/docs/d/core_vcns.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_vcns"
 sidebar_current: "docs-oci-datasource-core-vcns"

--- a/website/docs/d/core_virtual_circuit.html.markdown
+++ b/website/docs/d/core_virtual_circuit.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_virtual_circuit"
 sidebar_current: "docs-oci-datasource-core-virtual_circuit"

--- a/website/docs/d/core_virtual_circuit_bandwidth_shapes.html.markdown
+++ b/website/docs/d/core_virtual_circuit_bandwidth_shapes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_virtual_circuit_bandwidth_shapes"
 sidebar_current: "docs-oci-datasource-core-virtual_circuit_bandwidth_shapes"

--- a/website/docs/d/core_virtual_circuit_public_prefixes.html.markdown
+++ b/website/docs/d/core_virtual_circuit_public_prefixes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_virtual_circuit_public_prefixes"
 sidebar_current: "docs-oci-datasource-core-virtual_circuit_public_prefixes"

--- a/website/docs/d/core_virtual_circuits.html.markdown
+++ b/website/docs/d/core_virtual_circuits.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_virtual_circuits"
 sidebar_current: "docs-oci-datasource-core-virtual_circuits"

--- a/website/docs/d/core_vnic.html.markdown
+++ b/website/docs/d/core_vnic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_vnic"
 sidebar_current: "docs-oci-datasource-core-vnic"

--- a/website/docs/d/core_vnic_attachments.html.markdown
+++ b/website/docs/d/core_vnic_attachments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_vnic_attachments"
 sidebar_current: "docs-oci-datasource-core-vnic_attachments"

--- a/website/docs/d/core_volume.html.markdown
+++ b/website/docs/d/core_volume.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume"
 sidebar_current: "docs-oci-datasource-core-volume"

--- a/website/docs/d/core_volume_attachments.html.markdown
+++ b/website/docs/d/core_volume_attachments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_attachments"
 sidebar_current: "docs-oci-datasource-core-volume_attachments"

--- a/website/docs/d/core_volume_backup_policies.html.markdown
+++ b/website/docs/d/core_volume_backup_policies.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_backup_policies"
 sidebar_current: "docs-oci-datasource-core-volume_backup_policies"

--- a/website/docs/d/core_volume_backup_policy_assignments.html.markdown
+++ b/website/docs/d/core_volume_backup_policy_assignments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_backup_policy_assignments"
 sidebar_current: "docs-oci-datasource-core-volume_backup_policy_assignments"

--- a/website/docs/d/core_volume_backups.html.markdown
+++ b/website/docs/d/core_volume_backups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_backups"
 sidebar_current: "docs-oci-datasource-core-volume_backups"

--- a/website/docs/d/core_volume_group_backups.html.markdown
+++ b/website/docs/d/core_volume_group_backups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_group_backups"
 sidebar_current: "docs-oci-datasource-core-volume_group_backups"

--- a/website/docs/d/core_volume_groups.html.markdown
+++ b/website/docs/d/core_volume_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_groups"
 sidebar_current: "docs-oci-datasource-core-volume_groups"

--- a/website/docs/d/core_volumes.html.markdown
+++ b/website/docs/d/core_volumes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volumes"
 sidebar_current: "docs-oci-datasource-core-volumes"

--- a/website/docs/d/database_autonomous_container_database.html.markdown
+++ b/website/docs/d/database_autonomous_container_database.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_container_database"
 sidebar_current: "docs-oci-datasource-database-autonomous_container_database"

--- a/website/docs/d/database_autonomous_container_databases.html.markdown
+++ b/website/docs/d/database_autonomous_container_databases.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_container_databases"
 sidebar_current: "docs-oci-datasource-database-autonomous_container_databases"

--- a/website/docs/d/database_autonomous_data_warehouse.html.markdown
+++ b/website/docs/d/database_autonomous_data_warehouse.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_data_warehouse"
 sidebar_current: "docs-oci-datasource-database-autonomous_data_warehouse"

--- a/website/docs/d/database_autonomous_data_warehouse_backup.html.markdown
+++ b/website/docs/d/database_autonomous_data_warehouse_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_data_warehouse_backup"
 sidebar_current: "docs-oci-datasource-database-autonomous_data_warehouse_backup"

--- a/website/docs/d/database_autonomous_data_warehouse_backups.html.markdown
+++ b/website/docs/d/database_autonomous_data_warehouse_backups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_data_warehouse_backups"
 sidebar_current: "docs-oci-datasource-database-autonomous_data_warehouse_backups"

--- a/website/docs/d/database_autonomous_data_warehouse_wallet.html.markdown
+++ b/website/docs/d/database_autonomous_data_warehouse_wallet.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_data_warehouse_wallet"
 sidebar_current: "docs-oci-datasource-database-autonomous_data_warehouse_wallet"

--- a/website/docs/d/database_autonomous_data_warehouses.html.markdown
+++ b/website/docs/d/database_autonomous_data_warehouses.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_data_warehouses"
 sidebar_current: "docs-oci-datasource-database-autonomous_data_warehouses"

--- a/website/docs/d/database_autonomous_database.html.markdown
+++ b/website/docs/d/database_autonomous_database.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database"
 sidebar_current: "docs-oci-datasource-database-autonomous_database"

--- a/website/docs/d/database_autonomous_database_backup.html.markdown
+++ b/website/docs/d/database_autonomous_database_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database_backup"
 sidebar_current: "docs-oci-datasource-database-autonomous_database_backup"

--- a/website/docs/d/database_autonomous_database_backups.html.markdown
+++ b/website/docs/d/database_autonomous_database_backups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database_backups"
 sidebar_current: "docs-oci-datasource-database-autonomous_database_backups"

--- a/website/docs/d/database_autonomous_database_instance_wallet_management.html.markdown
+++ b/website/docs/d/database_autonomous_database_instance_wallet_management.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database_instance_wallet_management"
 sidebar_current: "docs-oci-datasource-database-autonomous_database_instance_wallet_management"

--- a/website/docs/d/database_autonomous_database_regional_wallet_management.html.markdown
+++ b/website/docs/d/database_autonomous_database_regional_wallet_management.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database_regional_wallet_management"
 sidebar_current: "docs-oci-datasource-database-autonomous_database_regional_wallet_management"

--- a/website/docs/d/database_autonomous_database_wallet.html.markdown
+++ b/website/docs/d/database_autonomous_database_wallet.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database_wallet"
 sidebar_current: "docs-oci-datasource-database-autonomous_database_wallet"

--- a/website/docs/d/database_autonomous_databases.html.markdown
+++ b/website/docs/d/database_autonomous_databases.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_databases"
 sidebar_current: "docs-oci-datasource-database-autonomous_databases"

--- a/website/docs/d/database_autonomous_db_preview_versions.html.markdown
+++ b/website/docs/d/database_autonomous_db_preview_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_db_preview_versions"
 sidebar_current: "docs-oci-datasource-database-autonomous_db_preview_versions"

--- a/website/docs/d/database_autonomous_exadata_infrastructure.html.markdown
+++ b/website/docs/d/database_autonomous_exadata_infrastructure.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_exadata_infrastructure"
 sidebar_current: "docs-oci-datasource-database-autonomous_exadata_infrastructure"

--- a/website/docs/d/database_autonomous_exadata_infrastructure_shapes.html.markdown
+++ b/website/docs/d/database_autonomous_exadata_infrastructure_shapes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_exadata_infrastructure_shapes"
 sidebar_current: "docs-oci-datasource-database-autonomous_exadata_infrastructure_shapes"

--- a/website/docs/d/database_autonomous_exadata_infrastructures.html.markdown
+++ b/website/docs/d/database_autonomous_exadata_infrastructures.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_exadata_infrastructures"
 sidebar_current: "docs-oci-datasource-database-autonomous_exadata_infrastructures"

--- a/website/docs/d/database_backup_destination.html.markdown
+++ b/website/docs/d/database_backup_destination.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_backup_destination"
 sidebar_current: "docs-oci-datasource-database-backup_destination"

--- a/website/docs/d/database_backup_destinations.html.markdown
+++ b/website/docs/d/database_backup_destinations.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_backup_destinations"
 sidebar_current: "docs-oci-datasource-database-backup_destinations"

--- a/website/docs/d/database_backups.html.markdown
+++ b/website/docs/d/database_backups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_backups"
 sidebar_current: "docs-oci-datasource-database-backups"

--- a/website/docs/d/database_data_guard_association.html.markdown
+++ b/website/docs/d/database_data_guard_association.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_data_guard_association"
 sidebar_current: "docs-oci-datasource-database-data_guard_association"

--- a/website/docs/d/database_data_guard_associations.html.markdown
+++ b/website/docs/d/database_data_guard_associations.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_data_guard_associations"
 sidebar_current: "docs-oci-datasource-database-data_guard_associations"

--- a/website/docs/d/database_database.html.markdown
+++ b/website/docs/d/database_database.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_database"
 sidebar_current: "docs-oci-datasource-database-database"

--- a/website/docs/d/database_databases.html.markdown
+++ b/website/docs/d/database_databases.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_databases"
 sidebar_current: "docs-oci-datasource-database-databases"

--- a/website/docs/d/database_db_home.html.markdown
+++ b/website/docs/d/database_db_home.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_home"
 sidebar_current: "docs-oci-datasource-database-db_home"

--- a/website/docs/d/database_db_home_patch_history_entries.html.markdown
+++ b/website/docs/d/database_db_home_patch_history_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_home_patch_history_entries"
 sidebar_current: "docs-oci-datasource-database-db_home_patch_history_entries"

--- a/website/docs/d/database_db_home_patches.html.markdown
+++ b/website/docs/d/database_db_home_patches.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_home_patches"
 sidebar_current: "docs-oci-datasource-database-db_home_patches"

--- a/website/docs/d/database_db_homes.html.markdown
+++ b/website/docs/d/database_db_homes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_homes"
 sidebar_current: "docs-oci-datasource-database-db_homes"

--- a/website/docs/d/database_db_node.html.markdown
+++ b/website/docs/d/database_db_node.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_node"
 sidebar_current: "docs-oci-datasource-database-db_node"

--- a/website/docs/d/database_db_nodes.html.markdown
+++ b/website/docs/d/database_db_nodes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_nodes"
 sidebar_current: "docs-oci-datasource-database-db_nodes"

--- a/website/docs/d/database_db_system_patch_history_entries.html.markdown
+++ b/website/docs/d/database_db_system_patch_history_entries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_system_patch_history_entries"
 sidebar_current: "docs-oci-datasource-database-db_system_patch_history_entries"

--- a/website/docs/d/database_db_system_patches.html.markdown
+++ b/website/docs/d/database_db_system_patches.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_system_patches"
 sidebar_current: "docs-oci-datasource-database-db_system_patches"

--- a/website/docs/d/database_db_system_shapes.html.markdown
+++ b/website/docs/d/database_db_system_shapes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_system_shapes"
 sidebar_current: "docs-oci-datasource-database-db_system_shapes"

--- a/website/docs/d/database_db_systems.html.markdown
+++ b/website/docs/d/database_db_systems.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_systems"
 sidebar_current: "docs-oci-datasource-database-db_systems"

--- a/website/docs/d/database_db_versions.html.markdown
+++ b/website/docs/d/database_db_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_versions"
 sidebar_current: "docs-oci-datasource-database-db_versions"

--- a/website/docs/d/database_exadata_infrastructure.html.markdown
+++ b/website/docs/d/database_exadata_infrastructure.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_exadata_infrastructure"
 sidebar_current: "docs-oci-datasource-database-exadata_infrastructure"

--- a/website/docs/d/database_exadata_infrastructure_download_config_file.html.markdown
+++ b/website/docs/d/database_exadata_infrastructure_download_config_file.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_exadata_infrastructure_download_config_file"
 sidebar_current: "docs-oci-datasource-database-exadata_infrastructure_download_config_file"

--- a/website/docs/d/database_exadata_infrastructures.html.markdown
+++ b/website/docs/d/database_exadata_infrastructures.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_exadata_infrastructures"
 sidebar_current: "docs-oci-datasource-database-exadata_infrastructures"

--- a/website/docs/d/database_exadata_iorm_config.html.markdown
+++ b/website/docs/d/database_exadata_iorm_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_exadata_iorm_config"
 sidebar_current: "docs-oci-datasource-database-exadata_iorm_config"

--- a/website/docs/d/database_gi_versions.html.markdown
+++ b/website/docs/d/database_gi_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_gi_versions"
 sidebar_current: "docs-oci-datasource-database-gi_versions"

--- a/website/docs/d/database_maintenance_run.html.markdown
+++ b/website/docs/d/database_maintenance_run.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_maintenance_run"
 sidebar_current: "docs-oci-datasource-database-maintenance_run"

--- a/website/docs/d/database_maintenance_runs.html.markdown
+++ b/website/docs/d/database_maintenance_runs.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_maintenance_runs"
 sidebar_current: "docs-oci-datasource-database-maintenance_runs"

--- a/website/docs/d/database_vm_cluster.html.markdown
+++ b/website/docs/d/database_vm_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_vm_cluster"
 sidebar_current: "docs-oci-datasource-database-vm_cluster"

--- a/website/docs/d/database_vm_cluster_network.html.markdown
+++ b/website/docs/d/database_vm_cluster_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_vm_cluster_network"
 sidebar_current: "docs-oci-datasource-database-vm_cluster_network"

--- a/website/docs/d/database_vm_cluster_network_download_config_file.html.markdown
+++ b/website/docs/d/database_vm_cluster_network_download_config_file.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_vm_cluster_network_download_config_file"
 sidebar_current: "docs-oci-datasource-database-vm_cluster_network_download_config_file"

--- a/website/docs/d/database_vm_cluster_networks.html.markdown
+++ b/website/docs/d/database_vm_cluster_networks.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_vm_cluster_networks"
 sidebar_current: "docs-oci-datasource-database-vm_cluster_networks"

--- a/website/docs/d/database_vm_cluster_recommended_network.html.markdown
+++ b/website/docs/d/database_vm_cluster_recommended_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_vm_cluster_recommended_network"
 sidebar_current: "docs-oci-datasource-database-vm_cluster_recommended_network"

--- a/website/docs/d/database_vm_clusters.html.markdown
+++ b/website/docs/d/database_vm_clusters.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_vm_clusters"
 sidebar_current: "docs-oci-datasource-database-vm_clusters"

--- a/website/docs/d/dns_records.html.markdown
+++ b/website/docs/d/dns_records.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_records"
 sidebar_current: "docs-oci-datasource-dns-records"

--- a/website/docs/d/dns_steering_policies.html.markdown
+++ b/website/docs/d/dns_steering_policies.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_steering_policies"
 sidebar_current: "docs-oci-datasource-dns-steering_policies"

--- a/website/docs/d/dns_steering_policy.html.markdown
+++ b/website/docs/d/dns_steering_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_steering_policy"
 sidebar_current: "docs-oci-datasource-dns-steering_policy"

--- a/website/docs/d/dns_steering_policy_attachment.html.markdown
+++ b/website/docs/d/dns_steering_policy_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_steering_policy_attachment"
 sidebar_current: "docs-oci-datasource-dns-steering_policy_attachment"

--- a/website/docs/d/dns_steering_policy_attachments.html.markdown
+++ b/website/docs/d/dns_steering_policy_attachments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_steering_policy_attachments"
 sidebar_current: "docs-oci-datasource-dns-steering_policy_attachments"

--- a/website/docs/d/dns_zones.html.markdown
+++ b/website/docs/d/dns_zones.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_zones"
 sidebar_current: "docs-oci-datasource-dns-zones"

--- a/website/docs/d/email_sender.html.markdown
+++ b/website/docs/d/email_sender.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Email"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_email_sender"
 sidebar_current: "docs-oci-datasource-email-sender"

--- a/website/docs/d/email_senders.html.markdown
+++ b/website/docs/d/email_senders.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Email"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_email_senders"
 sidebar_current: "docs-oci-datasource-email-senders"

--- a/website/docs/d/email_suppression.html.markdown
+++ b/website/docs/d/email_suppression.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Email"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_email_suppression"
 sidebar_current: "docs-oci-datasource-email-suppression"

--- a/website/docs/d/email_suppressions.html.markdown
+++ b/website/docs/d/email_suppressions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Email"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_email_suppressions"
 sidebar_current: "docs-oci-datasource-email-suppressions"

--- a/website/docs/d/events_rule.html.markdown
+++ b/website/docs/d/events_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Events"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_events_rule"
 sidebar_current: "docs-oci-datasource-events-rule"

--- a/website/docs/d/events_rules.html.markdown
+++ b/website/docs/d/events_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Events"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_events_rules"
 sidebar_current: "docs-oci-datasource-events-rules"

--- a/website/docs/d/file_storage_export_sets.html.markdown
+++ b/website/docs/d/file_storage_export_sets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_export_sets"
 sidebar_current: "docs-oci-datasource-file_storage-export_sets"

--- a/website/docs/d/file_storage_exports.html.markdown
+++ b/website/docs/d/file_storage_exports.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_exports"
 sidebar_current: "docs-oci-datasource-file_storage-exports"

--- a/website/docs/d/file_storage_file_systems.html.markdown
+++ b/website/docs/d/file_storage_file_systems.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_file_systems"
 sidebar_current: "docs-oci-datasource-file_storage-file_systems"

--- a/website/docs/d/file_storage_mount_targets.html.markdown
+++ b/website/docs/d/file_storage_mount_targets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_mount_targets"
 sidebar_current: "docs-oci-datasource-file_storage-mount_targets"

--- a/website/docs/d/file_storage_snapshot.html.markdown
+++ b/website/docs/d/file_storage_snapshot.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_snapshot"
 sidebar_current: "docs-oci-datasource-file_storage-snapshot"

--- a/website/docs/d/file_storage_snapshots.html.markdown
+++ b/website/docs/d/file_storage_snapshots.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_snapshots"
 sidebar_current: "docs-oci-datasource-file_storage-snapshots"

--- a/website/docs/d/functions_application.html.markdown
+++ b/website/docs/d/functions_application.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Functions"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_functions_application"
 sidebar_current: "docs-oci-datasource-functions-application"

--- a/website/docs/d/functions_applications.html.markdown
+++ b/website/docs/d/functions_applications.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Functions"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_functions_applications"
 sidebar_current: "docs-oci-datasource-functions-applications"

--- a/website/docs/d/functions_function.html.markdown
+++ b/website/docs/d/functions_function.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Functions"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_functions_function"
 sidebar_current: "docs-oci-datasource-functions-function"

--- a/website/docs/d/functions_functions.html.markdown
+++ b/website/docs/d/functions_functions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Functions"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_functions_functions"
 sidebar_current: "docs-oci-datasource-functions-functions"

--- a/website/docs/d/health_checks_http_monitor.html.markdown
+++ b/website/docs/d/health_checks_http_monitor.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_http_monitor"
 sidebar_current: "docs-oci-datasource-health_checks-http_monitor"

--- a/website/docs/d/health_checks_http_monitors.html.markdown
+++ b/website/docs/d/health_checks_http_monitors.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_http_monitors"
 sidebar_current: "docs-oci-datasource-health_checks-http_monitors"

--- a/website/docs/d/health_checks_http_probe_results.html.markdown
+++ b/website/docs/d/health_checks_http_probe_results.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_http_probe_results"
 sidebar_current: "docs-oci-datasource-health_checks-http_probe_results"

--- a/website/docs/d/health_checks_ping_monitor.html.markdown
+++ b/website/docs/d/health_checks_ping_monitor.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_ping_monitor"
 sidebar_current: "docs-oci-datasource-health_checks-ping_monitor"

--- a/website/docs/d/health_checks_ping_monitors.html.markdown
+++ b/website/docs/d/health_checks_ping_monitors.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_ping_monitors"
 sidebar_current: "docs-oci-datasource-health_checks-ping_monitors"

--- a/website/docs/d/health_checks_ping_probe_results.html.markdown
+++ b/website/docs/d/health_checks_ping_probe_results.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_ping_probe_results"
 sidebar_current: "docs-oci-datasource-health_checks-ping_probe_results"

--- a/website/docs/d/health_checks_vantage_points.html.markdown
+++ b/website/docs/d/health_checks_vantage_points.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_vantage_points"
 sidebar_current: "docs-oci-datasource-health_checks-vantage_points"

--- a/website/docs/d/identity_api_keys.html.markdown
+++ b/website/docs/d/identity_api_keys.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_api_keys"
 sidebar_current: "docs-oci-datasource-identity-api_keys"

--- a/website/docs/d/identity_auth_tokens.html.markdown
+++ b/website/docs/d/identity_auth_tokens.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_auth_tokens"
 sidebar_current: "docs-oci-datasource-identity-auth_tokens"

--- a/website/docs/d/identity_authentication_policy.html.markdown
+++ b/website/docs/d/identity_authentication_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_authentication_policy"
 sidebar_current: "docs-oci-datasource-identity-authentication_policy"

--- a/website/docs/d/identity_availability_domain.html.markdown
+++ b/website/docs/d/identity_availability_domain.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_availability_domain"
 sidebar_current: "docs-oci-datasource-identity-availability-domain"

--- a/website/docs/d/identity_availability_domains.html.markdown
+++ b/website/docs/d/identity_availability_domains.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_availability_domains"
 sidebar_current: "docs-oci-datasource-identity-availability_domains"

--- a/website/docs/d/identity_compartment.html.markdown
+++ b/website/docs/d/identity_compartment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_compartment"
 sidebar_current: "docs-oci-datasource-identity-compartment"

--- a/website/docs/d/identity_compartments.html.markdown
+++ b/website/docs/d/identity_compartments.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_compartments"
 sidebar_current: "docs-oci-datasource-identity-compartments"

--- a/website/docs/d/identity_cost_tracking_tags.html.markdown
+++ b/website/docs/d/identity_cost_tracking_tags.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_cost_tracking_tags"
 sidebar_current: "docs-oci-datasource-identity-cost_tracking_tags"

--- a/website/docs/d/identity_customer_secret_keys.html.markdown
+++ b/website/docs/d/identity_customer_secret_keys.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_customer_secret_keys"
 sidebar_current: "docs-oci-datasource-identity-customer_secret_keys"

--- a/website/docs/d/identity_dynamic_groups.html.markdown
+++ b/website/docs/d/identity_dynamic_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_dynamic_groups"
 sidebar_current: "docs-oci-datasource-identity-dynamic_groups"

--- a/website/docs/d/identity_fault_domains.html.markdown
+++ b/website/docs/d/identity_fault_domains.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_fault_domains"
 sidebar_current: "docs-oci-datasource-identity-fault_domains"

--- a/website/docs/d/identity_group.html.markdown
+++ b/website/docs/d/identity_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_group"
 sidebar_current: "docs-oci-datasource-identity-group"

--- a/website/docs/d/identity_groups.html.markdown
+++ b/website/docs/d/identity_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_groups"
 sidebar_current: "docs-oci-datasource-identity-groups"

--- a/website/docs/d/identity_identity_provider_groups.html.markdown
+++ b/website/docs/d/identity_identity_provider_groups.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_identity_provider_groups"
 sidebar_current: "docs-oci-datasource-identity-identity_provider_groups"

--- a/website/docs/d/identity_identity_providers.html.markdown
+++ b/website/docs/d/identity_identity_providers.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_identity_providers"
 sidebar_current: "docs-oci-datasource-identity-identity_providers"

--- a/website/docs/d/identity_idp_group_mappings.html.markdown
+++ b/website/docs/d/identity_idp_group_mappings.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_idp_group_mappings"
 sidebar_current: "docs-oci-datasource-identity-idp_group_mappings"

--- a/website/docs/d/identity_policies.html.markdown
+++ b/website/docs/d/identity_policies.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_policies"
 sidebar_current: "docs-oci-datasource-identity-policies"

--- a/website/docs/d/identity_region_subscriptions.html.markdown
+++ b/website/docs/d/identity_region_subscriptions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_region_subscriptions"
 sidebar_current: "docs-oci-datasource-identity-region_subscriptions"

--- a/website/docs/d/identity_regions.html.markdown
+++ b/website/docs/d/identity_regions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_regions"
 sidebar_current: "docs-oci-datasource-identity-regions"

--- a/website/docs/d/identity_smtp_credentials.html.markdown
+++ b/website/docs/d/identity_smtp_credentials.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_smtp_credentials"
 sidebar_current: "docs-oci-datasource-identity-smtp_credentials"

--- a/website/docs/d/identity_swift_passwords.html.markdown
+++ b/website/docs/d/identity_swift_passwords.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_swift_passwords"
 sidebar_current: "docs-oci-datasource-identity-swift_passwords"

--- a/website/docs/d/identity_tag_default.html.markdown
+++ b/website/docs/d/identity_tag_default.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_tag_default"
 sidebar_current: "docs-oci-datasource-identity-tag_default"

--- a/website/docs/d/identity_tag_defaults.html.markdown
+++ b/website/docs/d/identity_tag_defaults.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_tag_defaults"
 sidebar_current: "docs-oci-datasource-identity-tag_defaults"

--- a/website/docs/d/identity_tag_namespaces.html.markdown
+++ b/website/docs/d/identity_tag_namespaces.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_tag_namespaces"
 sidebar_current: "docs-oci-datasource-identity-tag_namespaces"

--- a/website/docs/d/identity_tags.html.markdown
+++ b/website/docs/d/identity_tags.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_tags"
 sidebar_current: "docs-oci-datasource-identity-tags"

--- a/website/docs/d/identity_tenancy.html.markdown
+++ b/website/docs/d/identity_tenancy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_tenancy"
 sidebar_current: "docs-oci-datasource-identity-tenancy"

--- a/website/docs/d/identity_ui_password.html.markdown
+++ b/website/docs/d/identity_ui_password.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_ui_password"
 sidebar_current: "docs-oci-datasource-identity-ui_password"

--- a/website/docs/d/identity_user.html.markdown
+++ b/website/docs/d/identity_user.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_user"
 sidebar_current: "docs-oci-datasource-identity-user"

--- a/website/docs/d/identity_user_group_memberships.html.markdown
+++ b/website/docs/d/identity_user_group_memberships.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_user_group_memberships"
 sidebar_current: "docs-oci-datasource-identity-user_group_memberships"

--- a/website/docs/d/identity_users.html.markdown
+++ b/website/docs/d/identity_users.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_users"
 sidebar_current: "docs-oci-datasource-identity-users"

--- a/website/docs/d/kms_decrypted_data.html.markdown
+++ b/website/docs/d/kms_decrypted_data.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "OCI: oci_kms_decrypted_data"
 sidebar_current: "docs-oci-datasource-kms-decrypted_data"

--- a/website/docs/d/kms_encrypted_data.html.markdown
+++ b/website/docs/d/kms_encrypted_data.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "OCI: oci_kms_encrypted_data"
 sidebar_current: "docs-oci-datasource-kms-encrypted_data"

--- a/website/docs/d/kms_key.html.markdown
+++ b/website/docs/d/kms_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_key"
 sidebar_current: "docs-oci-datasource-kms-key"

--- a/website/docs/d/kms_key_version.html.markdown
+++ b/website/docs/d/kms_key_version.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_key_version"
 sidebar_current: "docs-oci-datasource-kms-key_version"

--- a/website/docs/d/kms_key_versions.html.markdown
+++ b/website/docs/d/kms_key_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_key_versions"
 sidebar_current: "docs-oci-datasource-kms-key_versions"

--- a/website/docs/d/kms_keys.html.markdown
+++ b/website/docs/d/kms_keys.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_keys"
 sidebar_current: "docs-oci-datasource-kms-keys"

--- a/website/docs/d/kms_vault.html.markdown
+++ b/website/docs/d/kms_vault.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_vault"
 sidebar_current: "docs-oci-datasource-kms-vault"

--- a/website/docs/d/kms_vaults.html.markdown
+++ b/website/docs/d/kms_vaults.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_vaults"
 sidebar_current: "docs-oci-datasource-kms-vaults"

--- a/website/docs/d/limits_limit_definitions.html.markdown
+++ b/website/docs/d/limits_limit_definitions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Limits"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_limits_limit_definitions"
 sidebar_current: "docs-oci-datasource-limits-limit_definitions"

--- a/website/docs/d/limits_limit_values.html.markdown
+++ b/website/docs/d/limits_limit_values.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Limits"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_limits_limit_values"
 sidebar_current: "docs-oci-datasource-limits-limit_values"

--- a/website/docs/d/limits_quota.html.markdown
+++ b/website/docs/d/limits_quota.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Limits"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_limits_quota"
 sidebar_current: "docs-oci-datasource-limits-quota"

--- a/website/docs/d/limits_quotas.html.markdown
+++ b/website/docs/d/limits_quotas.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Limits"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_limits_quotas"
 sidebar_current: "docs-oci-datasource-limits-quotas"

--- a/website/docs/d/limits_resource_availability.html.markdown
+++ b/website/docs/d/limits_resource_availability.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Limits"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_limits_resource_availability"
 sidebar_current: "docs-oci-datasource-limits-resource_availability"

--- a/website/docs/d/limits_services.html.markdown
+++ b/website/docs/d/limits_services.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Limits"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_limits_services"
 sidebar_current: "docs-oci-datasource-limits-services"

--- a/website/docs/d/load_balancer_backend_health.html.markdown
+++ b/website/docs/d/load_balancer_backend_health.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_backend_health"
 sidebar_current: "docs-oci-datasource-load_balancer-backend_health"

--- a/website/docs/d/load_balancer_backend_set_health.html.markdown
+++ b/website/docs/d/load_balancer_backend_set_health.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_backend_set_health"
 sidebar_current: "docs-oci-datasource-load_balancer-backend_set_health"

--- a/website/docs/d/load_balancer_backend_sets.html.markdown
+++ b/website/docs/d/load_balancer_backend_sets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_backend_sets"
 sidebar_current: "docs-oci-datasource-load_balancer-backend_sets"

--- a/website/docs/d/load_balancer_backends.html.markdown
+++ b/website/docs/d/load_balancer_backends.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_backends"
 sidebar_current: "docs-oci-datasource-load_balancer-backends"

--- a/website/docs/d/load_balancer_certificates.html.markdown
+++ b/website/docs/d/load_balancer_certificates.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_certificates"
 sidebar_current: "docs-oci-datasource-load_balancer-certificates"

--- a/website/docs/d/load_balancer_health.html.markdown
+++ b/website/docs/d/load_balancer_health.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_health"
 sidebar_current: "docs-oci-datasource-load_balancer-load_balancer_health"

--- a/website/docs/d/load_balancer_hostnames.html.markdown
+++ b/website/docs/d/load_balancer_hostnames.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_hostnames"
 sidebar_current: "docs-oci-datasource-load_balancer-hostnames"

--- a/website/docs/d/load_balancer_listener_rules.html.markdown
+++ b/website/docs/d/load_balancer_listener_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_listener_rules"
 sidebar_current: "docs-oci-datasource-load_balancer-listener_rules"

--- a/website/docs/d/load_balancer_load_balancers.html.markdown
+++ b/website/docs/d/load_balancer_load_balancers.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_load_balancers"
 sidebar_current: "docs-oci-datasource-load_balancer-load_balancers"

--- a/website/docs/d/load_balancer_path_route_sets.html.markdown
+++ b/website/docs/d/load_balancer_path_route_sets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_path_route_sets"
 sidebar_current: "docs-oci-datasource-load_balancer-path_route_sets"

--- a/website/docs/d/load_balancer_policies.html.markdown
+++ b/website/docs/d/load_balancer_policies.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_policies"
 sidebar_current: "docs-oci-datasource-load_balancer-policies"

--- a/website/docs/d/load_balancer_protocols.html.markdown
+++ b/website/docs/d/load_balancer_protocols.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_protocols"
 sidebar_current: "docs-oci-datasource-load_balancer-protocols"

--- a/website/docs/d/load_balancer_rule_set.html.markdown
+++ b/website/docs/d/load_balancer_rule_set.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_rule_set"
 sidebar_current: "docs-oci-datasource-load_balancer-rule_set"

--- a/website/docs/d/load_balancer_rule_sets.html.markdown
+++ b/website/docs/d/load_balancer_rule_sets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_rule_sets"
 sidebar_current: "docs-oci-datasource-load_balancer-rule_sets"

--- a/website/docs/d/load_balancer_shapes.html.markdown
+++ b/website/docs/d/load_balancer_shapes.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_shapes"
 sidebar_current: "docs-oci-datasource-load_balancer-shapes"

--- a/website/docs/d/monitoring_alarm.html.markdown
+++ b/website/docs/d/monitoring_alarm.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Monitoring"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_monitoring_alarm"
 sidebar_current: "docs-oci-datasource-monitoring-alarm"

--- a/website/docs/d/monitoring_alarm_history_collection.html.markdown
+++ b/website/docs/d/monitoring_alarm_history_collection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Monitoring"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_monitoring_alarm_history_collection"
 sidebar_current: "docs-oci-datasource-monitoring-alarm_history_collection"

--- a/website/docs/d/monitoring_alarm_statuses.html.markdown
+++ b/website/docs/d/monitoring_alarm_statuses.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Monitoring"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_monitoring_alarm_statuses"
 sidebar_current: "docs-oci-datasource-monitoring-alarm_statuses"

--- a/website/docs/d/monitoring_alarms.html.markdown
+++ b/website/docs/d/monitoring_alarms.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Monitoring"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_monitoring_alarms"
 sidebar_current: "docs-oci-datasource-monitoring-alarms"

--- a/website/docs/d/monitoring_metric_data.html.markdown
+++ b/website/docs/d/monitoring_metric_data.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Monitoring"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_monitoring_metric_data"
 sidebar_current: "docs-oci-datasource-monitoring-metric_data"

--- a/website/docs/d/monitoring_metrics.html.markdown
+++ b/website/docs/d/monitoring_metrics.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Monitoring"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_monitoring_metrics"
 sidebar_current: "docs-oci-datasource-monitoring-metrics"

--- a/website/docs/d/objectstorage_bucket.html.markdown
+++ b/website/docs/d/objectstorage_bucket.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_bucket"
 sidebar_current: "docs-oci-datasource-objectstorage-bucket"

--- a/website/docs/d/objectstorage_bucket_summaries.html.markdown
+++ b/website/docs/d/objectstorage_bucket_summaries.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_bucket_summaries"
 sidebar_current: "docs-oci-datasource-objectstorage-bucket_summaries"

--- a/website/docs/d/objectstorage_namespace.html.markdown
+++ b/website/docs/d/objectstorage_namespace.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_namespace"
 sidebar_current: "docs-oci-datasource-objectstorage-namespace"

--- a/website/docs/d/objectstorage_object.html.markdown
+++ b/website/docs/d/objectstorage_object.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_object"
 sidebar_current: "docs-oci-datasource-objectstorage-object"

--- a/website/docs/d/objectstorage_object_head.html.markdown
+++ b/website/docs/d/objectstorage_object_head.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "OCI: oci_objectstorage_object_head"
 sidebar_current: "docs-oci-datasource-objectstorage-object_head"

--- a/website/docs/d/objectstorage_object_lifecycle_policy.html.markdown
+++ b/website/docs/d/objectstorage_object_lifecycle_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_object_lifecycle_policy"
 sidebar_current: "docs-oci-datasource-objectstorage-object_lifecycle_policy"

--- a/website/docs/d/objectstorage_objects.html.markdown
+++ b/website/docs/d/objectstorage_objects.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_objects"
 sidebar_current: "docs-oci-datasource-objectstorage-objects"

--- a/website/docs/d/objectstorage_preauthrequest.html.markdown
+++ b/website/docs/d/objectstorage_preauthrequest.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_preauthrequest"
 sidebar_current: "docs-oci-datasource-objectstorage-preauthenticated_request"

--- a/website/docs/d/objectstorage_preauthrequests.html.markdown
+++ b/website/docs/d/objectstorage_preauthrequests.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_preauthrequests"
 sidebar_current: "docs-oci-datasource-objectstorage-preauthrequests"

--- a/website/docs/d/oce_oce_instance.html.markdown
+++ b/website/docs/d/oce_oce_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Oce"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_oce_oce_instance"
 sidebar_current: "docs-oci-datasource-oce-oce_instance"

--- a/website/docs/d/oce_oce_instances.html.markdown
+++ b/website/docs/d/oce_oce_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Oce"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_oce_oce_instances"
 sidebar_current: "docs-oci-datasource-oce-oce_instances"

--- a/website/docs/d/oda_oda_instance.html.markdown
+++ b/website/docs/d/oda_oda_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Oda"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_oda_oda_instance"
 sidebar_current: "docs-oci-datasource-oda-oda_instance"

--- a/website/docs/d/oda_oda_instances.html.markdown
+++ b/website/docs/d/oda_oda_instances.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Oda"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_oda_oda_instances"
 sidebar_current: "docs-oci-datasource-oda-oda_instances"

--- a/website/docs/d/ons_notification_topic.html.markdown
+++ b/website/docs/d/ons_notification_topic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Ons"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_ons_notification_topic"
 sidebar_current: "docs-oci-datasource-ons-notification_topic"

--- a/website/docs/d/ons_notification_topics.html.markdown
+++ b/website/docs/d/ons_notification_topics.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Ons"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_ons_notification_topics"
 sidebar_current: "docs-oci-datasource-ons-notification_topics"

--- a/website/docs/d/ons_subscription.html.markdown
+++ b/website/docs/d/ons_subscription.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Ons"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_ons_subscription"
 sidebar_current: "docs-oci-datasource-ons-subscription"

--- a/website/docs/d/ons_subscriptions.html.markdown
+++ b/website/docs/d/ons_subscriptions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Ons"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_ons_subscriptions"
 sidebar_current: "docs-oci-datasource-ons-subscriptions"

--- a/website/docs/d/streaming_stream.html.markdown
+++ b/website/docs/d/streaming_stream.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Streaming"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_streaming_stream"
 sidebar_current: "docs-oci-datasource-streaming-stream"

--- a/website/docs/d/streaming_stream_archiver.html.markdown
+++ b/website/docs/d/streaming_stream_archiver.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Streaming"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_streaming_stream_archiver"
 sidebar_current: "docs-oci-datasource-streaming-stream_archiver"

--- a/website/docs/d/streaming_streams.html.markdown
+++ b/website/docs/d/streaming_streams.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Streaming"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_streaming_streams"
 sidebar_current: "docs-oci-datasource-streaming-streams"

--- a/website/docs/d/waas_address_list.html.markdown
+++ b/website/docs/d/waas_address_list.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_address_list"
 sidebar_current: "docs-oci-datasource-waas-address_list"

--- a/website/docs/d/waas_address_lists.html.markdown
+++ b/website/docs/d/waas_address_lists.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_address_lists"
 sidebar_current: "docs-oci-datasource-waas-address_lists"

--- a/website/docs/d/waas_certificate.html.markdown
+++ b/website/docs/d/waas_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_certificate"
 sidebar_current: "docs-oci-datasource-waas-certificate"

--- a/website/docs/d/waas_certificates.html.markdown
+++ b/website/docs/d/waas_certificates.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_certificates"
 sidebar_current: "docs-oci-datasource-waas-certificates"

--- a/website/docs/d/waas_custom_protection_rule.html.markdown
+++ b/website/docs/d/waas_custom_protection_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_custom_protection_rule"
 sidebar_current: "docs-oci-datasource-waas-custom_protection_rule"

--- a/website/docs/d/waas_custom_protection_rules.html.markdown
+++ b/website/docs/d/waas_custom_protection_rules.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_custom_protection_rules"
 sidebar_current: "docs-oci-datasource-waas-custom_protection_rules"

--- a/website/docs/d/waas_edge_subnets.html.markdown
+++ b/website/docs/d/waas_edge_subnets.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_edge_subnets"
 sidebar_current: "docs-oci-datasource-waas-edge_subnets"

--- a/website/docs/d/waas_http_redirect.html.markdown
+++ b/website/docs/d/waas_http_redirect.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_http_redirect"
 sidebar_current: "docs-oci-datasource-waas-http_redirect"

--- a/website/docs/d/waas_http_redirects.html.markdown
+++ b/website/docs/d/waas_http_redirects.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_http_redirects"
 sidebar_current: "docs-oci-datasource-waas-http_redirects"

--- a/website/docs/d/waas_waas_policies.html.markdown
+++ b/website/docs/d/waas_waas_policies.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_waas_policies"
 sidebar_current: "docs-oci-datasource-waas-waas_policies"

--- a/website/docs/d/waas_waas_policy.html.markdown
+++ b/website/docs/d/waas_waas_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_waas_policy"
 sidebar_current: "docs-oci-datasource-waas-waas_policy"

--- a/website/docs/r/audit_configuration.html.markdown
+++ b/website/docs/r/audit_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Audit"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_audit_configuration"
 sidebar_current: "docs-oci-resource-audit-configuration"

--- a/website/docs/r/autoscaling_auto_scaling_configuration.html.markdown
+++ b/website/docs/r/autoscaling_auto_scaling_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Auto Scaling"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_autoscaling_auto_scaling_configuration"
 sidebar_current: "docs-oci-resource-autoscaling-auto_scaling_configuration"

--- a/website/docs/r/budget_alert_rule.html.markdown
+++ b/website/docs/r/budget_alert_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Budget"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_budget_alert_rule"
 sidebar_current: "docs-oci-resource-budget-alert_rule"

--- a/website/docs/r/budget_budget.html.markdown
+++ b/website/docs/r/budget_budget.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Budget"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_budget_budget"
 sidebar_current: "docs-oci-resource-budget-budget"

--- a/website/docs/r/containerengine_cluster.html.markdown
+++ b/website/docs/r/containerengine_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_cluster"
 sidebar_current: "docs-oci-resource-containerengine-cluster"

--- a/website/docs/r/containerengine_node_pool.html.markdown
+++ b/website/docs/r/containerengine_node_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Container Engine"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_containerengine_node_pool"
 sidebar_current: "docs-oci-resource-containerengine-node_pool"

--- a/website/docs/r/core_app_catalog_listing_resource_version_agreement.html.markdown
+++ b/website/docs/r/core_app_catalog_listing_resource_version_agreement.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "OCI: oci_core_app_catalog_listing_resource_version_agreement"
 sidebar_current: "docs-oci-datasource-core-app_catalog_listing_resource_version_agreement"

--- a/website/docs/r/core_app_catalog_subscription.html.markdown
+++ b/website/docs/r/core_app_catalog_subscription.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_app_catalog_subscription"
 sidebar_current: "docs-oci-resource-core-app_catalog_subscription"

--- a/website/docs/r/core_boot_volume.html.markdown
+++ b/website/docs/r/core_boot_volume.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_boot_volume"
 sidebar_current: "docs-oci-resource-core-boot_volume"

--- a/website/docs/r/core_boot_volume_backup.html.markdown
+++ b/website/docs/r/core_boot_volume_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_boot_volume_backup"
 sidebar_current: "docs-oci-resource-core-boot_volume_backup"

--- a/website/docs/r/core_cluster_network.html.markdown
+++ b/website/docs/r/core_cluster_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cluster_network"
 sidebar_current: "docs-oci-resource-core-cluster_network"

--- a/website/docs/r/core_console_history.html.markdown
+++ b/website/docs/r/core_console_history.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_console_history"
 sidebar_current: "docs-oci-resource-core-console_history"

--- a/website/docs/r/core_cpe.html.markdown
+++ b/website/docs/r/core_cpe.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cpe"
 sidebar_current: "docs-oci-resource-core-cpe"

--- a/website/docs/r/core_cross_connect.html.markdown
+++ b/website/docs/r/core_cross_connect.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connect"
 sidebar_current: "docs-oci-resource-core-cross_connect"

--- a/website/docs/r/core_cross_connect_group.html.markdown
+++ b/website/docs/r/core_cross_connect_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_cross_connect_group"
 sidebar_current: "docs-oci-resource-core-cross_connect_group"

--- a/website/docs/r/core_dedicated_vm_host.html.markdown
+++ b/website/docs/r/core_dedicated_vm_host.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_dedicated_vm_host"
 sidebar_current: "docs-oci-resource-core-dedicated_vm_host"

--- a/website/docs/r/core_dhcp_options.html.markdown
+++ b/website/docs/r/core_dhcp_options.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_dhcp_options"
 sidebar_current: "docs-oci-resource-core-dhcp_options"

--- a/website/docs/r/core_drg.html.markdown
+++ b/website/docs/r/core_drg.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_drg"
 sidebar_current: "docs-oci-resource-core-drg"

--- a/website/docs/r/core_drg_attachment.html.markdown
+++ b/website/docs/r/core_drg_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_drg_attachment"
 sidebar_current: "docs-oci-resource-core-drg_attachment"

--- a/website/docs/r/core_image.html.markdown
+++ b/website/docs/r/core_image.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_image"
 sidebar_current: "docs-oci-resource-core-image"

--- a/website/docs/r/core_instance.html.markdown
+++ b/website/docs/r/core_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance"
 sidebar_current: "docs-oci-resource-core-instance"

--- a/website/docs/r/core_instance_configuration.html.markdown
+++ b/website/docs/r/core_instance_configuration.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_configuration"
 sidebar_current: "docs-oci-resource-core-instance_configuration"

--- a/website/docs/r/core_instance_console_connection.html.markdown
+++ b/website/docs/r/core_instance_console_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_console_connection"
 sidebar_current: "docs-oci-resource-core-instance_console_connection"

--- a/website/docs/r/core_instance_pool.html.markdown
+++ b/website/docs/r/core_instance_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_instance_pool"
 sidebar_current: "docs-oci-resource-core-instance_pool"

--- a/website/docs/r/core_internet_gateway.html.markdown
+++ b/website/docs/r/core_internet_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_internet_gateway"
 sidebar_current: "docs-oci-resource-core-internet_gateway"

--- a/website/docs/r/core_ipsec.html.markdown
+++ b/website/docs/r/core_ipsec.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_ipsec"
 sidebar_current: "docs-oci-resource-core-ipsec"

--- a/website/docs/r/core_ipsec_connection_tunnel_management.html.markdown
+++ b/website/docs/r/core_ipsec_connection_tunnel_management.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_ipsec_connection_tunnel_management"
 sidebar_current: "docs-oci-datasource-core-ip_sec_connection_tunnel_management"

--- a/website/docs/r/core_local_peering_gateway.html.markdown
+++ b/website/docs/r/core_local_peering_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_local_peering_gateway"
 sidebar_current: "docs-oci-resource-core-local_peering_gateway"

--- a/website/docs/r/core_nat_gateway.html.markdown
+++ b/website/docs/r/core_nat_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_nat_gateway"
 sidebar_current: "docs-oci-resource-core-nat_gateway"

--- a/website/docs/r/core_network_security_group.html.markdown
+++ b/website/docs/r/core_network_security_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_network_security_group"
 sidebar_current: "docs-oci-resource-core-network_security_group"

--- a/website/docs/r/core_network_security_group_security_rule.html.markdown
+++ b/website/docs/r/core_network_security_group_security_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_network_security_group_security_rule"
 sidebar_current: "docs-oci-resource-core-network_security_group_security_rule"

--- a/website/docs/r/core_private_ip.html.markdown
+++ b/website/docs/r/core_private_ip.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_private_ip"
 sidebar_current: "docs-oci-resource-core-private_ip"

--- a/website/docs/r/core_public_ip.html.markdown
+++ b/website/docs/r/core_public_ip.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_public_ip"
 sidebar_current: "docs-oci-resource-core-public_ip"

--- a/website/docs/r/core_remote_peering_connection.html.markdown
+++ b/website/docs/r/core_remote_peering_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_remote_peering_connection"
 sidebar_current: "docs-oci-resource-core-remote_peering_connection"

--- a/website/docs/r/core_route_table.html.markdown
+++ b/website/docs/r/core_route_table.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_route_table"
 sidebar_current: "docs-oci-resource-core-route_table"

--- a/website/docs/r/core_route_table_attachment.html.markdown
+++ b/website/docs/r/core_route_table_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "OCI: oci_core_route_table_attachment"
 sidebar_current: "docs-oci-resource-core-route-table-attachment"

--- a/website/docs/r/core_security_list.html.markdown
+++ b/website/docs/r/core_security_list.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_security_list"
 sidebar_current: "docs-oci-resource-core-security_list"

--- a/website/docs/r/core_service_gateway.html.markdown
+++ b/website/docs/r/core_service_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_service_gateway"
 sidebar_current: "docs-oci-resource-core-service_gateway"

--- a/website/docs/r/core_shape_management.html.markdown
+++ b/website/docs/r/core_shape_management.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_shape_management"
 sidebar_current: "docs-oci-resource-core-shape_management"
@@ -28,7 +29,7 @@ The following arguments are supported:
 
 * `compartment_id` - (Required) The OCID of the compartment containing the image.
 * `image_id` - (Required) The OCID of the Image to which the shape should be added.
-* `shape_name` - (Required) The compatible shape that is to be added to the compatible shapes list for the image. 
+* `shape_name` - (Required) The compatible shape that is to be added to the compatible shapes list for the image.
 
 ## Attributes Reference
 
@@ -36,4 +37,4 @@ The following attributes are exported:
 
 * `id` - The image's Oracle ID (OCID).
 * `image_id` - The OCID of the image containing the shape.
-* `shape_name` - The compatible Shape for the image.  
+* `shape_name` - The compatible Shape for the image.

--- a/website/docs/r/core_subnet.html.markdown
+++ b/website/docs/r/core_subnet.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_subnet"
 sidebar_current: "docs-oci-resource-core-subnet"

--- a/website/docs/r/core_vcn.html.markdown
+++ b/website/docs/r/core_vcn.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_vcn"
 sidebar_current: "docs-oci-resource-core-vcn"

--- a/website/docs/r/core_virtual_circuit.html.markdown
+++ b/website/docs/r/core_virtual_circuit.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_virtual_circuit"
 sidebar_current: "docs-oci-resource-core-virtual_circuit"

--- a/website/docs/r/core_vnic_attachment.html.markdown
+++ b/website/docs/r/core_vnic_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_vnic_attachment"
 sidebar_current: "docs-oci-resource-core-vnic_attachment"

--- a/website/docs/r/core_volume.html.markdown
+++ b/website/docs/r/core_volume.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume"
 sidebar_current: "docs-oci-resource-core-volume"

--- a/website/docs/r/core_volume_attachment.html.markdown
+++ b/website/docs/r/core_volume_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_attachment"
 sidebar_current: "docs-oci-resource-core-volume_attachment"

--- a/website/docs/r/core_volume_backup.html.markdown
+++ b/website/docs/r/core_volume_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_backup"
 sidebar_current: "docs-oci-resource-core-volume_backup"

--- a/website/docs/r/core_volume_backup_policy.html.markdown
+++ b/website/docs/r/core_volume_backup_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_backup_policy"
 sidebar_current: "docs-oci-resource-core-volume_backup_policy"

--- a/website/docs/r/core_volume_backup_policy_assignment.html.markdown
+++ b/website/docs/r/core_volume_backup_policy_assignment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_backup_policy_assignment"
 sidebar_current: "docs-oci-resource-core-volume_backup_policy_assignment"

--- a/website/docs/r/core_volume_group.html.markdown
+++ b/website/docs/r/core_volume_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_group"
 sidebar_current: "docs-oci-resource-core-volume_group"

--- a/website/docs/r/core_volume_group_backup.html.markdown
+++ b/website/docs/r/core_volume_group_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Core"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_core_volume_group_backup"
 sidebar_current: "docs-oci-resource-core-volume_group_backup"

--- a/website/docs/r/database_autonomous_container_database.html.markdown
+++ b/website/docs/r/database_autonomous_container_database.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_container_database"
 sidebar_current: "docs-oci-resource-database-autonomous_container_database"

--- a/website/docs/r/database_autonomous_data_warehouse.html.markdown
+++ b/website/docs/r/database_autonomous_data_warehouse.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_data_warehouse"
 sidebar_current: "docs-oci-resource-database-autonomous_data_warehouse"

--- a/website/docs/r/database_autonomous_data_warehouse_backup.html.markdown
+++ b/website/docs/r/database_autonomous_data_warehouse_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_data_warehouse_backup"
 sidebar_current: "docs-oci-resource-database-autonomous_data_warehouse_backup"

--- a/website/docs/r/database_autonomous_database.html.markdown
+++ b/website/docs/r/database_autonomous_database.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database"
 sidebar_current: "docs-oci-resource-database-autonomous_database"

--- a/website/docs/r/database_autonomous_database_backup.html.markdown
+++ b/website/docs/r/database_autonomous_database_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database_backup"
 sidebar_current: "docs-oci-resource-database-autonomous_database_backup"

--- a/website/docs/r/database_autonomous_database_instance_wallet_management.html.markdown
+++ b/website/docs/r/database_autonomous_database_instance_wallet_management.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database_instance_wallet_management"
 sidebar_current: "docs-oci-resource-database-autonomous_database_instance_wallet_management"

--- a/website/docs/r/database_autonomous_database_regional_wallet_management.html.markdown
+++ b/website/docs/r/database_autonomous_database_regional_wallet_management.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_database_regional_wallet_management"
 sidebar_current: "docs-oci-resource-database-autonomous_database_regional_wallet_management"

--- a/website/docs/r/database_autonomous_exadata_infrastructure.html.markdown
+++ b/website/docs/r/database_autonomous_exadata_infrastructure.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_autonomous_exadata_infrastructure"
 sidebar_current: "docs-oci-resource-database-autonomous_exadata_infrastructure"

--- a/website/docs/r/database_backup.html.markdown
+++ b/website/docs/r/database_backup.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_backup"
 sidebar_current: "docs-oci-resource-database-backup"

--- a/website/docs/r/database_backup_destination.html.markdown
+++ b/website/docs/r/database_backup_destination.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_backup_destination"
 sidebar_current: "docs-oci-resource-database-backup_destination"

--- a/website/docs/r/database_data_guard_association.html.markdown
+++ b/website/docs/r/database_data_guard_association.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_data_guard_association"
 sidebar_current: "docs-oci-resource-database-data_guard_association"

--- a/website/docs/r/database_db_home.html.markdown
+++ b/website/docs/r/database_db_home.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_home"
 sidebar_current: "docs-oci-resource-database-db_home"

--- a/website/docs/r/database_db_system.html.markdown
+++ b/website/docs/r/database_db_system.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_db_system"
 sidebar_current: "docs-oci-resource-database-db_system"

--- a/website/docs/r/database_exadata_infrastructure.html.markdown
+++ b/website/docs/r/database_exadata_infrastructure.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_exadata_infrastructure"
 sidebar_current: "docs-oci-resource-database-exadata_infrastructure"

--- a/website/docs/r/database_exadata_iorm_config.html.markdown
+++ b/website/docs/r/database_exadata_iorm_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_exadata_iorm_config"
 sidebar_current: "docs-oci-resource-database-exadata_iorm_config"

--- a/website/docs/r/database_maintenance_run.html.markdown
+++ b/website/docs/r/database_maintenance_run.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_maintenance_run"
 sidebar_current: "docs-oci-resource-database-maintenance_run"

--- a/website/docs/r/database_vm_cluster.html.markdown
+++ b/website/docs/r/database_vm_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_vm_cluster"
 sidebar_current: "docs-oci-resource-database-vm_cluster"

--- a/website/docs/r/database_vm_cluster_network.html.markdown
+++ b/website/docs/r/database_vm_cluster_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Database"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_database_vm_cluster_network"
 sidebar_current: "docs-oci-resource-database-vm_cluster_network"

--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_record"
 sidebar_current: "docs-oci-resource-dns-record"

--- a/website/docs/r/dns_steering_policy.html.markdown
+++ b/website/docs/r/dns_steering_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_steering_policy"
 sidebar_current: "docs-oci-resource-dns-steering_policy"

--- a/website/docs/r/dns_steering_policy_attachment.html.markdown
+++ b/website/docs/r/dns_steering_policy_attachment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_steering_policy_attachment"
 sidebar_current: "docs-oci-resource-dns-steering_policy_attachment"

--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Dns"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_dns_zone"
 sidebar_current: "docs-oci-resource-dns-zone"

--- a/website/docs/r/email_sender.html.markdown
+++ b/website/docs/r/email_sender.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Email"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_email_sender"
 sidebar_current: "docs-oci-resource-email-sender"

--- a/website/docs/r/email_suppression.html.markdown
+++ b/website/docs/r/email_suppression.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Email"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_email_suppression"
 sidebar_current: "docs-oci-resource-email-suppression"

--- a/website/docs/r/events_rule.html.markdown
+++ b/website/docs/r/events_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Events"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_events_rule"
 sidebar_current: "docs-oci-resource-events-rule"

--- a/website/docs/r/file_storage_export.html.markdown
+++ b/website/docs/r/file_storage_export.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_export"
 sidebar_current: "docs-oci-resource-file_storage-export"

--- a/website/docs/r/file_storage_export_set.html.markdown
+++ b/website/docs/r/file_storage_export_set.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_export_set"
 sidebar_current: "docs-oci-resource-file_storage-export_set"

--- a/website/docs/r/file_storage_file_system.html.markdown
+++ b/website/docs/r/file_storage_file_system.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_file_system"
 sidebar_current: "docs-oci-resource-file_storage-file_system"

--- a/website/docs/r/file_storage_mount_target.html.markdown
+++ b/website/docs/r/file_storage_mount_target.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_mount_target"
 sidebar_current: "docs-oci-resource-file_storage-mount_target"

--- a/website/docs/r/file_storage_snapshot.html.markdown
+++ b/website/docs/r/file_storage_snapshot.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "File Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_file_storage_snapshot"
 sidebar_current: "docs-oci-resource-file_storage-snapshot"

--- a/website/docs/r/functions_application.html.markdown
+++ b/website/docs/r/functions_application.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Functions"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_functions_application"
 sidebar_current: "docs-oci-resource-functions-application"

--- a/website/docs/r/functions_function.html.markdown
+++ b/website/docs/r/functions_function.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Functions"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_functions_function"
 sidebar_current: "docs-oci-resource-functions-function"

--- a/website/docs/r/functions_invoke_function.html.markdown
+++ b/website/docs/r/functions_invoke_function.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Functions"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_functions_invoke_function"
 sidebar_current: "docs-oci-resource-functions-invoke_function"

--- a/website/docs/r/health_checks_http_monitor.html.markdown
+++ b/website/docs/r/health_checks_http_monitor.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_http_monitor"
 sidebar_current: "docs-oci-resource-health_checks-http_monitor"

--- a/website/docs/r/health_checks_http_probe.html.markdown
+++ b/website/docs/r/health_checks_http_probe.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_http_probe"
 sidebar_current: "docs-oci-resource-health_checks-http_probe"

--- a/website/docs/r/health_checks_ping_monitor.html.markdown
+++ b/website/docs/r/health_checks_ping_monitor.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_ping_monitor"
 sidebar_current: "docs-oci-resource-health_checks-ping_monitor"

--- a/website/docs/r/health_checks_ping_probe.html.markdown
+++ b/website/docs/r/health_checks_ping_probe.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Health Checks"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_health_checks_ping_probe"
 sidebar_current: "docs-oci-resource-health_checks-ping_probe"

--- a/website/docs/r/identity_api_key.html.markdown
+++ b/website/docs/r/identity_api_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_api_key"
 sidebar_current: "docs-oci-resource-identity-api_key"

--- a/website/docs/r/identity_auth_token.html.markdown
+++ b/website/docs/r/identity_auth_token.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_auth_token"
 sidebar_current: "docs-oci-resource-identity-auth_token"

--- a/website/docs/r/identity_authentication_policy.html.markdown
+++ b/website/docs/r/identity_authentication_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_authentication_policy"
 sidebar_current: "docs-oci-resource-identity-authentication_policy"

--- a/website/docs/r/identity_compartment.html.markdown
+++ b/website/docs/r/identity_compartment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_compartment"
 sidebar_current: "docs-oci-resource-identity-compartment"

--- a/website/docs/r/identity_customer_secret_key.html.markdown
+++ b/website/docs/r/identity_customer_secret_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_customer_secret_key"
 sidebar_current: "docs-oci-resource-identity-customer_secret_key"

--- a/website/docs/r/identity_dynamic_group.html.markdown
+++ b/website/docs/r/identity_dynamic_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_dynamic_group"
 sidebar_current: "docs-oci-resource-identity-dynamic_group"

--- a/website/docs/r/identity_group.html.markdown
+++ b/website/docs/r/identity_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_group"
 sidebar_current: "docs-oci-resource-identity-group"

--- a/website/docs/r/identity_identity_provider.html.markdown
+++ b/website/docs/r/identity_identity_provider.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_identity_provider"
 sidebar_current: "docs-oci-resource-identity-identity_provider"

--- a/website/docs/r/identity_idp_group_mapping.html.markdown
+++ b/website/docs/r/identity_idp_group_mapping.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_idp_group_mapping"
 sidebar_current: "docs-oci-resource-identity-idp_group_mapping"

--- a/website/docs/r/identity_policy.html.markdown
+++ b/website/docs/r/identity_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_policy"
 sidebar_current: "docs-oci-resource-identity-policy"

--- a/website/docs/r/identity_smtp_credential.html.markdown
+++ b/website/docs/r/identity_smtp_credential.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_smtp_credential"
 sidebar_current: "docs-oci-resource-identity-smtp_credential"

--- a/website/docs/r/identity_swift_password.html.markdown
+++ b/website/docs/r/identity_swift_password.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_swift_password"
 sidebar_current: "docs-oci-resource-identity-swift_password"

--- a/website/docs/r/identity_tag.html.markdown
+++ b/website/docs/r/identity_tag.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_tag"
 sidebar_current: "docs-oci-resource-identity-tag"

--- a/website/docs/r/identity_tag_default.html.markdown
+++ b/website/docs/r/identity_tag_default.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_tag_default"
 sidebar_current: "docs-oci-resource-identity-tag_default"

--- a/website/docs/r/identity_tag_namespace.html.markdown
+++ b/website/docs/r/identity_tag_namespace.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_tag_namespace"
 sidebar_current: "docs-oci-resource-identity-tag_namespace"

--- a/website/docs/r/identity_ui_password.html.markdown
+++ b/website/docs/r/identity_ui_password.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_ui_password"
 sidebar_current: "docs-oci-resource-identity-ui_password"

--- a/website/docs/r/identity_user.html.markdown
+++ b/website/docs/r/identity_user.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_user"
 sidebar_current: "docs-oci-resource-identity-user"

--- a/website/docs/r/identity_user_capabilities_management.html.markdown
+++ b/website/docs/r/identity_user_capabilities_management.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_user"
 sidebar_current: "docs-oci-resource-identity-user_capabilities"

--- a/website/docs/r/identity_user_group_membership.html.markdown
+++ b/website/docs/r/identity_user_group_membership.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Identity"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_identity_user_group_membership"
 sidebar_current: "docs-oci-resource-identity-user_group_membership"

--- a/website/docs/r/kms_encrypted_data.html.markdown
+++ b/website/docs/r/kms_encrypted_data.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_encrypted_data"
 sidebar_current: "docs-oci-resource-kms-encrypted_data"

--- a/website/docs/r/kms_generated_key.html.markdown
+++ b/website/docs/r/kms_generated_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_generated_key"
 sidebar_current: "docs-oci-resource-kms-generated_key"

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_key"
 sidebar_current: "docs-oci-resource-kms-key"

--- a/website/docs/r/kms_key_version.html.markdown
+++ b/website/docs/r/kms_key_version.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_key_version"
 sidebar_current: "docs-oci-resource-kms-key_version"

--- a/website/docs/r/kms_vault.html.markdown
+++ b/website/docs/r/kms_vault.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Kms"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_kms_vault"
 sidebar_current: "docs-oci-resource-kms-vault"

--- a/website/docs/r/limits_quota.html.markdown
+++ b/website/docs/r/limits_quota.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Limits"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_limits_quota"
 sidebar_current: "docs-oci-resource-limits-quota"

--- a/website/docs/r/load_balancer_backend.html.markdown
+++ b/website/docs/r/load_balancer_backend.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_backend"
 sidebar_current: "docs-oci-resource-load_balancer-backend"

--- a/website/docs/r/load_balancer_backend_set.html.markdown
+++ b/website/docs/r/load_balancer_backend_set.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_backend_set"
 sidebar_current: "docs-oci-resource-load_balancer-backend_set"

--- a/website/docs/r/load_balancer_certificate.html.markdown
+++ b/website/docs/r/load_balancer_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_certificate"
 sidebar_current: "docs-oci-resource-load_balancer-certificate"

--- a/website/docs/r/load_balancer_hostname.html.markdown
+++ b/website/docs/r/load_balancer_hostname.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_hostname"
 sidebar_current: "docs-oci-resource-load_balancer-hostname"

--- a/website/docs/r/load_balancer_listener.html.markdown
+++ b/website/docs/r/load_balancer_listener.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_listener"
 sidebar_current: "docs-oci-resource-load_balancer-listener"

--- a/website/docs/r/load_balancer_load_balancer.html.markdown
+++ b/website/docs/r/load_balancer_load_balancer.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_load_balancer"
 sidebar_current: "docs-oci-resource-load_balancer-load_balancer"

--- a/website/docs/r/load_balancer_path_route_set.html.markdown
+++ b/website/docs/r/load_balancer_path_route_set.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_path_route_set"
 sidebar_current: "docs-oci-resource-load_balancer-path_route_set"

--- a/website/docs/r/load_balancer_rule_set.html.markdown
+++ b/website/docs/r/load_balancer_rule_set.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Load Balancer"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_load_balancer_rule_set"
 sidebar_current: "docs-oci-resource-load_balancer-rule_set"

--- a/website/docs/r/monitoring_alarm.html.markdown
+++ b/website/docs/r/monitoring_alarm.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Monitoring"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_monitoring_alarm"
 sidebar_current: "docs-oci-resource-monitoring-alarm"

--- a/website/docs/r/objectstorage_bucket.html.markdown
+++ b/website/docs/r/objectstorage_bucket.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_bucket"
 sidebar_current: "docs-oci-resource-objectstorage-bucket"

--- a/website/docs/r/objectstorage_object.html.markdown
+++ b/website/docs/r/objectstorage_object.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_object"
 sidebar_current: "docs-oci-resource-objectstorage-object"

--- a/website/docs/r/objectstorage_object_lifecycle_policy.html.markdown
+++ b/website/docs/r/objectstorage_object_lifecycle_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_object_lifecycle_policy"
 sidebar_current: "docs-oci-resource-objectstorage-object_lifecycle_policy"

--- a/website/docs/r/objectstorage_preauthrequest.html.markdown
+++ b/website/docs/r/objectstorage_preauthrequest.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Object Storage"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_objectstorage_preauthrequest"
 sidebar_current: "docs-oci-resource-objectstorage-preauthrequest"

--- a/website/docs/r/oce_oce_instance.html.markdown
+++ b/website/docs/r/oce_oce_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Oce"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_oce_oce_instance"
 sidebar_current: "docs-oci-resource-oce-oce_instance"

--- a/website/docs/r/oda_oda_instance.html.markdown
+++ b/website/docs/r/oda_oda_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Oda"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_oda_oda_instance"
 sidebar_current: "docs-oci-resource-oda-oda_instance"

--- a/website/docs/r/ons_notification_topic.html.markdown
+++ b/website/docs/r/ons_notification_topic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Ons"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_ons_notification_topic"
 sidebar_current: "docs-oci-resource-ons-notification_topic"

--- a/website/docs/r/ons_subscription.html.markdown
+++ b/website/docs/r/ons_subscription.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Ons"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_ons_subscription"
 sidebar_current: "docs-oci-resource-ons-subscription"

--- a/website/docs/r/streaming_stream.html.markdown
+++ b/website/docs/r/streaming_stream.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Streaming"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_streaming_stream"
 sidebar_current: "docs-oci-resource-streaming-stream"

--- a/website/docs/r/streaming_stream_archiver.html.markdown
+++ b/website/docs/r/streaming_stream_archiver.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Streaming"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_streaming_stream_archiver"
 sidebar_current: "docs-oci-resource-streaming-stream_archiver"

--- a/website/docs/r/waas_address_list.html.markdown
+++ b/website/docs/r/waas_address_list.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_address_list"
 sidebar_current: "docs-oci-resource-waas-address_list"

--- a/website/docs/r/waas_certificate.html.markdown
+++ b/website/docs/r/waas_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_certificate"
 sidebar_current: "docs-oci-resource-waas-certificate"

--- a/website/docs/r/waas_custom_protection_rule.html.markdown
+++ b/website/docs/r/waas_custom_protection_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_custom_protection_rule"
 sidebar_current: "docs-oci-resource-waas-custom_protection_rule"

--- a/website/docs/r/waas_http_redirect.html.markdown
+++ b/website/docs/r/waas_http_redirect.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_http_redirect"
 sidebar_current: "docs-oci-resource-waas-http_redirect"

--- a/website/docs/r/waas_purge_cache.html.markdown
+++ b/website/docs/r/waas_purge_cache.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_purge_cache"
 sidebar_current: "docs-oci-resource-waas-purge_cache"

--- a/website/docs/r/waas_waas_policy.html.markdown
+++ b/website/docs/r/waas_waas_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Waas"
 layout: "oci"
 page_title: "Oracle Cloud Infrastructure: oci_waas_waas_policy"
 sidebar_current: "docs-oci-resource-waas-waas_policy"


### PR DESCRIPTION
    We will soon be displaying documentation for this provider both on
    [terraform.io](https://www.terraform.io/docs/providers/index.html)
    and on [the Terraform Registry](https://registry.terraform.io/providers).

    Documentation displayed on the Terraform Registry will not use the ERB
    layout containing the existing navigation, and will instead build the
    navigation dynamically based on the directory and YAML frontmatter of a file.
    For providers that group similar resources and data sources by service or
    use case (subcategories), we'll need to add this information to the
    Markdown source file.

    This PR modifies Resource and Data Source documentation source files by
    adding a subcategory to the metadata if those files were grouped previously.

    For more information about how documentation is rendered on the
    Terraform Registry, please see this reference:
    [Terraform Registry - Provider Documentation](https://www.terraform.io/docs/registry/providers/docs.html).