### PR TITLE
website: Fix new broken links to https://docs.cloud.oracle.com/iaas/api/

### DIFF
--- a/website/docs/d/kms_key_versions.html.markdown
+++ b/website/docs/d/kms_key_versions.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # Data Source: oci_kms_key_versions
 This data source provides the list of Key Versions in Oracle Cloud Infrastructure Kms service.
 
-Lists all [KeyVersion](/api/#/en/key/release/KeyVersion/) resources for the specified 
+Lists all [KeyVersion](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/KeyVersion/) resources for the specified
 master encryption key.
 
 As a management operation, this call is subject to a Key Management limit that applies to the total number 

--- a/website/docs/d/kms_vault.html.markdown
+++ b/website/docs/d/kms_vault.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `compartment_id` - The OCID of the compartment that contains a particular vault.
-* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include  [Encrypt](/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](/api/#/en/key/release/DecryptedData/Decrypt),  and [GenerateDataEncryptionKey](/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
+* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include  [Encrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/DecryptedData/Decrypt),  and [GenerateDataEncryptionKey](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations.
 * `defined_tags` - Defined tags for this resource. Each key is predefined and scoped to a namespace.  For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Operations.CostCenter": "42"}` 
 * `display_name` - A user-friendly name for the vault. It does not have to be unique, and it is changeable. Avoid entering confidential information. 
 * `freeform_tags` - Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.  For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Department": "Finance"}` 

--- a/website/docs/d/kms_vaults.html.markdown
+++ b/website/docs/d/kms_vaults.html.markdown
@@ -45,7 +45,7 @@ The following attributes are exported:
 The following attributes are exported:
 
 * `compartment_id` - The OCID of the compartment that contains a particular vault.
-* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include  [Encrypt](/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](/api/#/en/key/release/DecryptedData/Decrypt),  and [GenerateDataEncryptionKey](/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
+* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include  [Encrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/DecryptedData/Decrypt),  and [GenerateDataEncryptionKey](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations.
 * `defined_tags` - Defined tags for this resource. Each key is predefined and scoped to a namespace.  For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Operations.CostCenter": "42"}` 
 * `display_name` - A user-friendly name for the vault. It does not have to be unique, and it is changeable. Avoid entering confidential information. 
 * `freeform_tags` - Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.  For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Department": "Finance"}` 

--- a/website/docs/r/kms_encrypted_data.html.markdown
+++ b/website/docs/r/kms_encrypted_data.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # oci_kms_encrypted_data
 This resource provides the Encrypted Data resource in Oracle Cloud Infrastructure Kms service.
 
-Encrypts data using the given [EncryptDataDetails](/api/#/en/key/release/datatypes/EncryptDataDetails) resource. 
+Encrypts data using the given [EncryptDataDetails](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/datatypes/EncryptDataDetails) resource.
 Plaintext included in the example request is a base64-encoded value of a UTF-8 string.
 
 

--- a/website/docs/r/kms_generated_key.html.markdown
+++ b/website/docs/r/kms_generated_key.html.markdown
@@ -55,8 +55,8 @@ Any change to a property that does not support update will force the destruction
 The following attributes are exported:
 
 * `ciphertext` - The encrypted data encryption key generated from a master encryption key.
-* `plaintext` - The plaintext data encryption key, a base64-encoded sequence of random bytes, which is  included if the [GenerateDataEncryptionKey](/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey)  request includes the `includePlaintextKey` parameter and sets its value to "true". 
-* `plaintext_checksum` - The checksum of the plaintext data encryption key, which is included if the  [GenerateDataEncryptionKey](/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey)  request includes the `includePlaintextKey` parameter and sets its value to "true". 
+* `plaintext` - The plaintext data encryption key, a base64-encoded sequence of random bytes, which is  included if the [GenerateDataEncryptionKey](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey)  request includes the `includePlaintextKey` parameter and sets its value to "true".
+* `plaintext_checksum` - The checksum of the plaintext data encryption key, which is included if the  [GenerateDataEncryptionKey](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey)  request includes the `includePlaintextKey` parameter and sets its value to "true".
 
 ## Import
 

--- a/website/docs/r/kms_key_version.html.markdown
+++ b/website/docs/r/kms_key_version.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # oci_kms_key_version
 This resource provides the Key Version resource in Oracle Cloud Infrastructure Kms service.
 
-Generates a new [KeyVersion](/api/#/en/key/release/KeyVersion/) resource that provides new cryptographic 
+Generates a new [KeyVersion](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/KeyVersion/) resource that provides new cryptographic
 material for a master encryption key. The key must be in an ENABLED state to be rotated.
 
 As a management operation, this call is subject to a Key Management limit that applies to the total number 

--- a/website/docs/r/kms_vault.html.markdown
+++ b/website/docs/r/kms_vault.html.markdown
@@ -55,7 +55,7 @@ Any change to a property that does not support update will force the destruction
 The following attributes are exported:
 
 * `compartment_id` - The OCID of the compartment that contains a particular vault.
-* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include  [Encrypt](/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](/api/#/en/key/release/DecryptedData/Decrypt),  and [GenerateDataEncryptionKey](/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
+* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include  [Encrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/DecryptedData/Decrypt),  and [GenerateDataEncryptionKey](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations.
 * `defined_tags` - Defined tags for this resource. Each key is predefined and scoped to a namespace.  For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Operations.CostCenter": "42"}` 
 * `display_name` - A user-friendly name for the vault. It does not have to be unique, and it is changeable. Avoid entering confidential information. 
 * `freeform_tags` - Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.  For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Department": "Finance"}` 

--- a/website/docs/r/marketplace_accepted_agreement.html.markdown
+++ b/website/docs/r/marketplace_accepted_agreement.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `freeform_tags` - (Optional) (Updatable) Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).  Example: `{"Department": "Finance"}` 
 * `listing_id` - (Required) The unique identifier for the listing associated with the agreement.
 * `package_version` - (Required) The package version associated with the agreement.
-* `signature` - (Required) A signature generated for the listing package agreements that you can retrieve with [GetAgreement](/api/#/en/marketplace/20181001/Agreement/GetAgreement). 
+* `signature` - (Required) A signature generated for the listing package agreements that you can retrieve with [GetAgreement](https://docs.cloud.oracle.com/iaas/api/#/en/marketplace/20181001/Agreement/GetAgreement).
 
 
 ** IMPORTANT **


### PR DESCRIPTION
These appear as broken links when docs are displayed on terraform.io.