### PR TITLE
website: fix broken link to Oracle docs

### DIFF
--- a/website/docs/d/identity_tag.html.markdown
+++ b/website/docs/d/identity_tag.html.markdown
@@ -48,7 +48,7 @@ The following attributes are exported:
 
 	If you use the default validiator (or don't define a validator), the user applying the tag  enters a value. No additional validation is performed.
 
-	To clear the validator, call UpdateTag with  [DefaultTagDefinitionValidator](/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator). 
+	To clear the validator, call UpdateTag with  [DefaultTagDefinitionValidator](https://docs.cloud.oracle.com/iaas/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator).
 	* `validator_type` - Specifies the type of validation: a static value (no validation) or a list.  
 	* `values` - The list of allowed values for a definedTag value. 
 


### PR DESCRIPTION
Since these provider docs are displayed on many places that are not an
Oracle.com domain, they can't use bare paths without domain names when linking
to Oracle docs.