### PR TITLE
DNS Import Support

### DIFF
--- a/website/docs/r/dns_record.html.markdown
+++ b/website/docs/r/dns_record.html.markdown
@@ -64,5 +64,8 @@ The following attributes are exported:
 
 ## Import
 
-Import is not supported for this resource.
+DNS records can be imported using the `zone`, `domain`, `rtype`, `record_hash` and, optionally, the `compartment_id`, e.g.
 
+```
+$ terraform import module.dp_dns.oci_dns_record.test_record "zones/{zone}/records/{domain}/rtypes/{rtype}/recordHashes/{record_hash}[/compartmentId/{compartment_id}]"
+```


### PR DESCRIPTION
Adds support for DNS resource imports and updates the web markdown accordingly. Imports look like:
`terraform import 'module.my_module.oci_dns_record.test_record' 'zones/<zone>/records/<domain>/rtypes/<rtype>/recordHashes/<record hash>'`

optionally you can attach `compartmentId/<compartment id>` at the end. 

This pattern is open to discussion, I just followed what I have seen elsewhere for DNS in the API.

Signed-off-by: Harvey Lowndes <harvey.lowndes@oracle.com>