### PR TITLE
website: Fix more broken links to Oracle API docs

### DIFF
--- a/website/docs/d/identity_tag.html.markdown
+++ b/website/docs/d/identity_tag.html.markdown
@@ -48,7 +48,7 @@ The following attributes are exported:
 
 	If you use the default validiator (or don't define a validator), the user applying the tag  enters a value. No additional validation is performed.
 
-	To clear the validator, call UpdateTag with  [DefaultTagDefinitionValidator](/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator). 
+	To clear the validator, call UpdateTag with  [DefaultTagDefinitionValidator](https://docs.cloud.oracle.com/iaas/api/#/en/identity/latest/datatypes/DefaultTagDefinitionValidator). 
 	* `validator_type` - Specifies the type of validation: a static value (no validation) or a list.  
 	* `values` - The list of allowed values for a definedTag value. 
 

--- a/website/docs/d/kms_key_versions.html.markdown
+++ b/website/docs/d/kms_key_versions.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # Data Source: oci_kms_key_versions
 This data source provides the list of Key Versions in Oracle Cloud Infrastructure Kms service.
 
-Lists all [KeyVersion](/api/#/en/key/release/KeyVersion/) resources for the specified
+Lists all [KeyVersion](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/KeyVersion/) resources for the specified
 master encryption key.
 
 As a management operation, this call is subject to a Key Management limit that applies to the total number

--- a/website/docs/d/kms_vault.html.markdown
+++ b/website/docs/d/kms_vault.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `compartment_id` - The OCID of the compartment that contains a particular vault.
-* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include [Encrypt](/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](/api/#/en/key/release/DecryptedData/Decrypt), and [GenerateDataEncryptionKey](/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
+* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include [Encrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/DecryptedData/Decrypt), and [GenerateDataEncryptionKey](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
 * `defined_tags` - Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Operations.CostCenter": "42"}` 
 * `display_name` - A user-friendly name for the vault. It does not have to be unique, and it is changeable. Avoid entering confidential information. 
 * `freeform_tags` - Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Department": "Finance"}` 

--- a/website/docs/d/kms_vaults.html.markdown
+++ b/website/docs/d/kms_vaults.html.markdown
@@ -45,7 +45,7 @@ The following attributes are exported:
 The following attributes are exported:
 
 * `compartment_id` - The OCID of the compartment that contains a particular vault.
-* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include [Encrypt](/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](/api/#/en/key/release/DecryptedData/Decrypt), and [GenerateDataEncryptionKey](/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
+* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include [Encrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/DecryptedData/Decrypt), and [GenerateDataEncryptionKey](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
 * `defined_tags` - Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Operations.CostCenter": "42"}` 
 * `display_name` - A user-friendly name for the vault. It does not have to be unique, and it is changeable. Avoid entering confidential information. 
 * `freeform_tags` - Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Department": "Finance"}` 

--- a/website/docs/r/kms_vault.html.markdown
+++ b/website/docs/r/kms_vault.html.markdown
@@ -55,7 +55,7 @@ Any change to a property that does not support update will force the destruction
 The following attributes are exported:
 
 * `compartment_id` - The OCID of the compartment that contains a particular vault.
-* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include [Encrypt](/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](/api/#/en/key/release/DecryptedData/Decrypt), and [GenerateDataEncryptionKey](/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
+* `crypto_endpoint` - The service endpoint to perform cryptographic operations against. Cryptographic operations include [Encrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/EncryptedData/Encrypt), [Decrypt](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/DecryptedData/Decrypt), and [GenerateDataEncryptionKey](https://docs.cloud.oracle.com/iaas/api/#/en/key/release/GeneratedKey/GenerateDataEncryptionKey) operations. 
 * `defined_tags` - Defined tags for this resource. Each key is predefined and scoped to a namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Operations.CostCenter": "42"}` 
 * `display_name` - A user-friendly name for the vault. It does not have to be unique, and it is changeable. Avoid entering confidential information. 
 * `freeform_tags` - Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Department": "Finance"}` 

--- a/website/docs/r/marketplace_accepted_agreement.html.markdown
+++ b/website/docs/r/marketplace_accepted_agreement.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `freeform_tags` - (Optional) (Updatable) The freeform tags associated with this resource, if any. Each tag is a simple key-value pair with no predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm). Example: `{"Department": "Finance"}` 
 * `listing_id` - (Required) The unique identifier for the listing associated with the agreement.
 * `package_version` - (Required) The package version associated with the agreement.
-* `signature` - (Required) A signature generated for the listing package agreements that you can retrieve with [GetAgreement](/api/#/en/marketplace/20181001/Agreement/GetAgreement). 
+* `signature` - (Required) A signature generated for the listing package agreements that you can retrieve with [GetAgreement](https://docs.cloud.oracle.com/iaas/api/#/en/marketplace/20181001/Agreement/GetAgreement). 
 
 
 ** IMPORTANT **


### PR DESCRIPTION
Hello again! These links are broken when displayed on both terraform.io and registry.terraform.io; additionally, they're causing nuisance failures in CI for the terraform.io website. 

It might be worth creating a github action for PRs and merges to this repository that makes sure the regular expression `\]\(/api/` doesn't match in any of the files under ./website. 