### PR TITLE
docs: reinstate Resource Discovery heading

### DIFF
--- a/website/docs/guides/resource_discovery.html.markdown
+++ b/website/docs/guides/resource_discovery.html.markdown
@@ -6,6 +6,8 @@ description: |-
   The Oracle Cloud Infrastructure provider. Discovering resources in an existing compartment
 ---
 
+## Resource Discovery
+
 ### Overview
 
 You can use Terraform Resource Discovery to discover deployed resources in your compartment and export them to Terraform configuration and state files. This release supports the most commonly used Oracle Cloud Infrastructure services, such as Compute, Block Volumes, Networking, Load Balancing, Database, and Identity and Access Management (IAM). Please look at the section “Supported Resources” for details.


### PR DESCRIPTION
It looks like the heading for the [Resource Discovery docs page](https://www.terraform.io/docs/providers/oci/guides/resource_discovery.html) was accidentally removed in https://github.com/terraform-providers/terraform-provider-oci/commit/c6ab0a4bf6f6296386a69694bd5c184e909baada.

This PR reinstates it in a shorter format. The original heading was "Discovering Terraform resources in an Oracle Cloud Infrastructure compartment", which the team may prefer.