### PR TITLE
fixed formatting for core_instance

### DIFF
--- a/website/docs/r/core_instance.html.markdown
+++ b/website/docs/r/core_instance.html.markdown
@@ -216,11 +216,19 @@ The following arguments are supported:
 
 	**Metadata Example**
 
-	"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_public_SSH_key>==" } **Getting Metadata on the Instance**
+	```
+	"metadata" : { "quake_bot_level" : "Severe", "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227", "user_data" : "<your_public_SSH_key>==" }
+	```
+
+	**Getting Metadata on the Instance**
 
 	To get information about your instance, connect to the instance using SSH and issue any of the following GET requests:
 
-	curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/ curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/ curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
+	```
+	curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/
+	curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/
+	curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
+	```
 
 	You'll get back a response that includes all the instance information; only the metadata information; or the metadata information for the specified key name, respectively.
 	


### PR DESCRIPTION
This PR fixes the preformatted sections related to the Metadata documentation:

<img width="859" alt="Screenshot 2020-06-01 at 09 20 46" src="https://user-images.githubusercontent.com/1161924/83385360-5d862000-a3e9-11ea-9c43-69956e55ae63.png">

Thanks,
Krastin