### PR TITLE
Avoid chunked HTTP requests for Object Storage

### DIFF
--- a/oci/objectstorage_object_resource.go
+++ b/oci/objectstorage_object_resource.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -591,11 +592,15 @@ func (s *ObjectStorageObjectResourceCrud) createContentObject() error {
 		tmp := []byte(content.(string))
 		tmpLength := int64(len(tmp))
 		request.ContentLength = &tmpLength
-		request.PutObjectBody = ioutil.NopCloser(bytes.NewBuffer(tmp))
+		if tmpLength == 0 {
+			request.PutObjectBody = http.NoBody
+		} else {
+			request.PutObjectBody = ioutil.NopCloser(bytes.NewBuffer(tmp))
+		}
 	} else {
 		tmp := int64(0)
 		request.ContentLength = &tmp
-		request.PutObjectBody = ioutil.NopCloser(bytes.NewBuffer([]byte{}))
+		request.PutObjectBody = http.NoBody
 	}
 
 	if metadata, ok := s.D.GetOkExists("metadata"); ok {


### PR DESCRIPTION
In go net/http, the recommend way to signal an empty body
is using http.NoBody. (or leaving the body nil.) With this
patch, for empty strings and empty body cases, we use
http.NoBody explicitly to avoid any accidental chunked
transfer encoding in HTTP requests.

Before this change, the issue can be identified by the presence
of "Transfer-Encoding: chunked" header and absence of "Content-Length"
header in the requests.

Signed-off-by: Tolga Ceylan <tolga.ceylan@oracle.com>