### PR TITLE
Revert "Added work request support to core instance and image resource"

### DIFF
--- a/oci/core_image_resource.go
+++ b/oci/core_image_resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	oci_core "github.com/oracle/oci-go-sdk/v27/core"
-	oci_work_requests "github.com/oracle/oci-go-sdk/v27/workrequests"
 )
 
 func init() {
@@ -232,7 +231,6 @@ func createCoreImage(d *schema.ResourceData, m interface{}) error {
 	sync := &CoreImageResourceCrud{}
 	sync.D = d
 	sync.Client = m.(*OracleClients).computeClient()
-	sync.workRequestClient = m.(*OracleClients).workRequestClient
 
 	return CreateResource(d, sync)
 }
@@ -265,7 +263,6 @@ func deleteCoreImage(d *schema.ResourceData, m interface{}) error {
 type CoreImageResourceCrud struct {
 	BaseCrud
 	Client                 *oci_core.ComputeClient
-	workRequestClient      *oci_work_requests.WorkRequestClient
 	Res                    *oci_core.Image
 	DisableNotFoundRetries bool
 }
@@ -349,14 +346,6 @@ func (s *CoreImageResourceCrud) Create() error {
 	response, err := s.Client.CreateImage(context.Background(), request)
 	if err != nil {
 		return err
-	}
-
-	workId := response.OpcWorkRequestId
-	if workId != nil {
-		_, err = WaitForWorkRequestWithErrorHandling(s.workRequestClient, workId, "image", oci_work_requests.WorkRequestResourceActionTypeCreated, s.D.Timeout(schema.TimeoutCreate), s.DisableNotFoundRetries)
-		if err != nil {
-			return err
-		}
 	}
 
 	s.Res = &response.Image

--- a/oci/core_instance_resource.go
+++ b/oci/core_instance_resource.go
@@ -515,7 +515,6 @@ func createCoreInstance(d *schema.ResourceData, m interface{}) error {
 	sync.Client = m.(*OracleClients).computeClient()
 	sync.VirtualNetworkClient = m.(*OracleClients).virtualNetworkClient()
 	sync.BlockStorageClient = m.(*OracleClients).blockstorageClient()
-	sync.workRequestClient = m.(*OracleClients).workRequestClient
 
 	var powerOff = false
 	if powerState, ok := sync.D.GetOkExists("state"); ok {
@@ -808,14 +807,6 @@ func (s *CoreInstanceResourceCrud) Create() error {
 	response, err := s.Client.LaunchInstance(context.Background(), request)
 	if err != nil {
 		return err
-	}
-
-	workId := response.OpcWorkRequestId
-	if workId != nil {
-		_, err = WaitForWorkRequestWithErrorHandling(s.workRequestClient, workId, "instance", oci_work_requests.WorkRequestResourceActionTypeCreated, s.D.Timeout(schema.TimeoutCreate), s.DisableNotFoundRetries)
-		if err != nil {
-			return err
-		}
 	}
 
 	s.Res = &response.Instance


### PR DESCRIPTION
This reverts commit 5765c9f3a3ca8d270e40700775b6d369c1fe6e77.

Reason for revert is to avoid situation where timeout errors from workrequest polling causes resource to be dangled.
Workrequest logic needs work before it can be enabled.