### PR TITLE
Fix wrong connection strings in lookup function of autonomous_database.tf example file

### DIFF
--- a/examples/database/adb/autonomous_database.tf
+++ b/examples/database/adb/autonomous_database.tf
@@ -130,7 +130,7 @@ output "autonomous_database_admin_password" {
 output "autonomous_database_high_connection_string" {
   value = lookup(
     oci_database_autonomous_database.autonomous_database.connection_strings[0].all_connection_strings,
-    "high",
+    "HIGH",
     "unavailable",
   )
 }


### PR DESCRIPTION
This is the fix for submitted issue of https://github.com/terraform-providers/terraform-provider-oci/issues/1377