### PR TITLE
Add Learn link to OCI provider

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -10,6 +10,9 @@ The Oracle Cloud Infrastructure provider is used to interact with the resources 
 
 The Oracle Cloud Infrastructure (OCI) provider allows you to use Terraform to interact with [Oracle Cloud Infrastructure](https://cloud.oracle.com/cloud-infrastructure) resources. Wherever you use a Terraform distribution you can use the OCI Terraform provider, including [Terraform Cloud](https://www.terraform.io/docs/cloud/index.html) and the OCI [Resource Manager](#resource-manager).
 
+To learn the basics of Terraform using this provider, follow the
+hands-on [get started tutorials](https://learn.hashicorp.com/tutorials/terraform/infrastructure-as-code?in=terraform/oci-get-started) on HashiCorp's Learn platform.
+
 ## Terraform CLI
 
 For details on configuring the OCI Terraform provider and using it with the Terraform CLI, refer to the [official OCI Terraform provider documentation](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/terraform.htm), which includes:


### PR DESCRIPTION
Add a link to our get started OCI tutorials to the docs for the OCI provider. This addition is the same language we use in the docs for other providers, but let me know if we need any changes. Thanks!